### PR TITLE
[IMP][8.0][purchase_quotation_products] Filters

### DIFF
--- a/purchase_quotation_products/purchase.py
+++ b/purchase_quotation_products/purchase.py
@@ -19,13 +19,16 @@ class purchase_order(models.Model):
         search_view_id = self.env['ir.model.data'].xmlid_to_res_id(
             'purchase_quotation_products.product_product_search_view')
         actions = self.env.ref(
-            'product.product_normal_action_sell')
+            'product.product_normal_action')
         if actions:
             action_read = actions.read()[0]
             context = literal_eval(action_read['context'])
             context['pricelist'] = self.pricelist_id.display_name
             # we send company in context so it filters taxes
             context['company_id'] = self.company_id.id
+            # we apply some default filters
+            context['search_default_filter_to_purchase'] = 1
+            context['search_default_seller_id'] = self.partner_id.id
             action_read['context'] = context
             # this search view removes pricelist
             action_read.pop("search_view", None)


### PR DESCRIPTION
Removed default filter "Can be Sold" (by changing default action)
Added default filter "Can be Purchased"
Added default filter 'seller_id' to match Purchase Order's supplier.

Relacionado a una incidencia que les cargué hoy.. al final lo pude resolver solo.
Me faltaría agregar el stock mínimo y máximo, que todavía no se bien cómo hacerlo.. si me ayudan con eso sería genial.