### PR TITLE
[9.0][product_usability] FIX 'Add Purchase Lines' multicompany.

### DIFF
--- a/purchase_usability/__openerp__.py
+++ b/purchase_usability/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     'name': 'Purchase Usability Improvements',
-    'version': '9.0.1.16.0',
+    'version': '9.0.1.17.0',
     'category': 'Purchases',
     'sequence': 14,
     'summary': '',

--- a/purchase_usability/models/account_invoice.py
+++ b/purchase_usability/models/account_invoice.py
@@ -25,6 +25,5 @@ class AccountInvoice(models.Model):
             action_read['domain'] = [
                 ('partner_id.commercial_partner_id', '=',
                     self.partner_id.commercial_partner_id.id),
-                ('company_id', '=', self.company_id.id),
             ]
         return action_read

--- a/purchase_usability/models/purchase_order_line.py
+++ b/purchase_usability/models/purchase_order_line.py
@@ -378,6 +378,16 @@ class PurchaseOrderLine(models.Model):
                 data['invoice_id'] = invoice_id
                 new_line = purchase_lines.new(data)
                 new_line._set_additional_fields(invoice)
+                # we force cache update of company_id value on invoice lines
+                # this fix right tax choose
+                # prevent price and name being overwrited
+                if self.company_id != invoice.company_id:
+                    price_unit = new_line.price_unit
+                    name = new_line.name
+                    new_line.company_id = invoice.company_id
+                    new_line._onchange_product_id()
+                    new_line.name = name
+                    new_line.price_unit = price_unit
                 vals = new_line._convert_to_write(new_line._cache)
                 purchase_lines.create(vals)
             # recomputamos impuestos


### PR DESCRIPTION
Esto permite importar lineas de ordenes de compras de otras compañias.

Tienen un access rule, así que incluso modificando este dominio, solo es posible importar líneas pertenecientes a las compañias hijas de la compañia del usuario.

Soluciona este issue: https://www.adhoc.com.ar/my/issues/9882