### PR TITLE
[FIX] purchase_quotation_products: set partner_id to vals when create…

### DIFF
--- a/purchase_quotation_products/models/purchase_order.py
+++ b/purchase_quotation_products/models/purchase_order.py
@@ -48,6 +48,7 @@ class PurchaseOrder(models.Model):
         vals = {
             'order_id': self.id,
             'product_id': product.id or False,
+            'partner_id': self.partner_id.id,
         }
         purchase_line = self.env['purchase.order.line'].new(vals)
         purchase_line.onchange_product_id()


### PR DESCRIPTION
… a purchase line

This is because the product description with provider needs the partner value to show the internal provider name