### PR TITLE
[REL] purchase_mrp_ux : Migration to 12.0

### DIFF
--- a/purchase_mrp_ux/__manifest__.py
+++ b/purchase_mrp_ux/__manifest__.py
@@ -29,7 +29,7 @@
     'depends': [
         'purchase_mrp',
     ],
-    'installable': False,
+    'installable': True,
     'auto_install': False,
     'application': False,
 }

--- a/purchase_mrp_ux/models/purchase_order_line.py
+++ b/purchase_mrp_ux/models/purchase_order_line.py
@@ -22,4 +22,4 @@ class PurchaseOrderLine(models.Model):
                     ", ".join(self.move_ids.filtered(
                         lambda x: x.to_refund).mapped('product_id.name')),
                     ))
-        return super(PurchaseOrderLine, self)._get_bom_delivered(bom=bom)
+        return super()._get_bom_delivered(bom=bom)


### PR DESCRIPTION
[FIX] Uses the simplex way to call the super()