### PR TITLE
[12.0] [PORT] from 11.0

### DIFF
--- a/purchase_ux/models/account_invoice.py
+++ b/purchase_ux/models/account_invoice.py
@@ -48,7 +48,7 @@ class AccountInvoice(models.Model):
     def update_prices_with_supplier_cost(self):
         net_price_installed = 'net_price' in self.env[
             'product.supplierinfo']._fields
-        for rec in self.invoice_line_ids.filtered('price_unit'):
+        for rec in self.invoice_line_ids.filtered(lambda x: x.product_id and x.price_unit):
             seller = rec.product_id._select_seller(
                 partner_id=rec.invoice_id.partner_id,
                 # usamos minimo de cantidad 0 porque si no seria complicado


### PR DESCRIPTION
[11.0] [FIX] purchase_ux: fix a bug related to a singleton error. (#79)

In the method to update the price with the supplier cost, if you try to apply and have at lest one line without a product, then raise an singleton error. To avoid this we filter the lines who has product and price setted.