### PR TITLE
[11.0] [FIX] purchase_ux: Problems with update supplier prices

### DIFF
--- a/purchase_ux/models/account_invoice.py
+++ b/purchase_ux/models/account_invoice.py
@@ -48,7 +48,8 @@ class AccountInvoice(models.Model):
     def update_prices_with_supplier_cost(self):
         net_price_installed = 'net_price' in self.env[
             'product.supplierinfo']._fields
-        for rec in self.invoice_line_ids.filtered(lambda x: x.product_id and x.price_unit):
+        for rec in self.with_context(
+                force_company=self.company_id.id).invoice_line_ids.filtered(lambda x: x.product_id and x.price_unit):
             seller = rec.product_id._select_seller(
                 partner_id=rec.invoice_id.partner_id,
                 # usamos minimo de cantidad 0 porque si no seria complicado
@@ -65,7 +66,9 @@ class AccountInvoice(models.Model):
                     'date_start': rec.invoice_id.date_invoice and
                     rec.invoice_id.date_invoice[:10],
                     'name': rec.invoice_id.partner_id.id,
+                    'currency_id': rec.invoice_id.partner_id.property_purchase_currency_id.id or self.currency_id.id,
                     'product_tmpl_id': rec.product_id.product_tmpl_id.id,
+                    'company_id': self.company_id.id,
                 })
             price_unit = rec.price_unit
             if rec.uom_id and seller.product_uom != rec.uom_id:

--- a/purchase_ux/models/purchase_order.py
+++ b/purchase_ux/models/purchase_order.py
@@ -156,7 +156,7 @@ class PurchaseOrder(models.Model):
     def update_prices_with_supplier_cost(self):
         net_price_installed = 'net_price' in self.env[
             'product.supplierinfo']._fields
-        for rec in self.order_line.filtered('price_unit'):
+        for rec in self.order_line.with_context(force_company=self.company_id.id).filtered('price_unit'):
             seller = rec.product_id._select_seller(
                 partner_id=rec.order_id.partner_id,
                 # usamos minimo de cantidad 0 porque si no seria complicado
@@ -173,7 +173,9 @@ class PurchaseOrder(models.Model):
                     'date_start': rec.order_id.date_order and
                     rec.order_id.date_order[:10],
                     'name': rec.order_id.partner_id.id,
+                    'currency_id': rec.order_id.partner_id.property_purchase_currency_id.id or self.currency_id.id,
                     'product_tmpl_id': rec.product_id.product_tmpl_id.id,
+                    'company_id': self.company_id.id,
                 })
             price_unit = rec.price_unit
             if rec.product_uom and seller.product_uom != rec.product_uom:


### PR DESCRIPTION
The problems it becase the field currency has a default who setted the user company currency.
To solve this problem when create the supplier info we set the currency and the company of the first, use the partner property currency if not use the order currency, the second use the company of the order/invoice.

Ticket 23855