### PR TITLE
[12.0] [FIX] purchase_ux: remove field depend that bring an error

### DIFF
--- a/purchase_ux/models/purchase_order.py
+++ b/purchase_ux/models/purchase_order.py
@@ -17,7 +17,7 @@ class PurchaseOrder(models.Model):
         copy=False,
     )
 
-    @api.depends('force_invoiced_status', 'order_line.move_ids.state')
+    @api.depends('force_invoiced_status')
     def _get_invoiced(self):
         for order in self:
             if order.state not in ('purchase', 'done'):


### PR DESCRIPTION
Remove this depends becase the field move_ids is from stock an now this module only depens from purchase.
And it's not necessary now to update values