### PR TITLE
[12.0] [PORT] from 11.0

### DIFF
--- a/purchase_ux/models/account_invoice.py
+++ b/purchase_ux/models/account_invoice.py
@@ -62,7 +62,7 @@ class AccountInvoice(models.Model):
                 uom_id=False,
             )
             if not seller:
-                seller = self.env['product.supplierinfo'].create({
+                seller = self.env['product.supplierinfo'].sudo().create({
                     'date_start': rec.invoice_id.date_invoice and
                     rec.invoice_id.date_invoice.date(),
                     'name': rec.invoice_id.partner_id.id,


### PR DESCRIPTION
[11.0] [FIX] purchase_ux: use sudo to create supplierinfo (#84)

We solve this for this scenario:
If you are in an multi-company environment, and you try to update supplier price using the button who creates supplier info. In the case that the company of the invoice is different that the one who are logging now, but you see the invoice becase it's a child of the company main.
Because of this rule  https://github.com/odoo/odoo/blob/11.0/addons/product/security/product_security.xml#L60 you can't create supplier info for a different company than the user has.