### PR TITLE
[12.0] [FIX] purchase_stock_ux: Fix an error with stock dropshipping

### DIFF
--- a/purchase_stock_ux/models/stock_rule.py
+++ b/purchase_stock_ux/models/stock_rule.py
@@ -13,9 +13,7 @@ class StockRule(models.Model):
             self, product_id, product_qty, product_uom, values, po, partner):
         self.ensure_one()
         res = super()._prepare_purchase_order_line(
-            product_id=product_id, product_qty=product_qty,
-            product_uom=product_uom, values=values,
-            po=po, partner=partner)
+            product_id, product_qty, product_uom, values, po, partner)
         # if price was not computed (not seller or seller price = 0.0), then
         # use standar price
         if not res['price_unit']:


### PR DESCRIPTION
It's not necesarry to use name of variable = variable, this cause an error when the variable name is changed.