### PR TITLE
[11.0] [FIX] purchase_suggest: Maintain consistency with the unit of …

### DIFF
--- a/purchase_suggest/wizard/purchase_suggest.py
+++ b/purchase_suggest/wizard/purchase_suggest.py
@@ -93,6 +93,8 @@ class PurchaseSuggestGenerate(models.TransientModel):
                     reste, 0.0,
                     precision_rounding=qty_dict['uom_rounding']) > 0:
                 qty_to_order += qty_multiple - reste
+            if product.uom_id != product.uom_po_id:
+                qty_to_order = product.uom_id._compute_quantity(qty_to_order, product.uom_po_id)
 
         sline = {
             'company_id': (


### PR DESCRIPTION
…measure

In case of product uom has different between purchase and sale, the quantity to order should be expressed in the purchase uom.