### PR TITLE
[FIX] purchase_ux: add purchase line button

### DIFF
--- a/purchase_ux/models/account_move.py
+++ b/purchase_ux/models/account_move.py
@@ -46,7 +46,7 @@ class AccountMove(models.Model):
         actions = self.env.ref(
             'purchase_ux.action_purchase_line_tree')
         if actions:
-            action_read = actions.read()[0]
+            action_read = actions.sudo().read()[0]
             context = literal_eval(action_read['context'])
             context.update(dict(
                 force_line_edit=True,


### PR DESCRIPTION
ticket 56110
---

Regular user not with Admin rights have a permission error when click this button on the vender billsL "not able to read ir.actions.act_window" this is because the button is trying to read a action and returned to the user, need to do it with sudo to avoid error.