### PR TITLE
[FIX]purchase_stock_ux: create one PO if used supplier's currency

### DIFF
--- a/purchase_stock_ux/models/stock_rule.py
+++ b/purchase_stock_ux/models/stock_rule.py
@@ -54,6 +54,7 @@ class StockRule(models.Model):
         domain = super()._make_po_get_domain(company_id, values, partner)
         current_user_id = self.env.user.id
         new_domain = []
+        config = self.env["res.config.settings"].sudo().get_values()
         for condition in domain:
             field, operator, value = condition
             if field == "user_id" and value == False:
@@ -64,18 +65,14 @@ class StockRule(models.Model):
                         ("user_id", "=", current_user_id),
                     ]
                 )
+            elif (
+                field == "currency_id"
+                and config.get("use_supplier_currency", False)
+                and partner.property_purchase_currency_id
+                and partner.property_purchase_currency_id.id != value
+            ):
+                value = partner.property_purchase_currency_id.id
+                new_domain.append((field, operator, value))
             else:
                 new_domain.append(condition)
         return tuple(new_domain)
-
-    def _prepare_purchase_order(self, company_id, origins, values):
-        order_vals = super()._prepare_purchase_order(company_id, origins, values)
-        config = self.env["res.config.settings"].sudo().get_values()
-        if config.get("use_supplier_currency", False):
-            values = values[0]
-            partner = values["supplier"].partner_id
-            if partner.property_purchase_currency_id:
-                order_vals["currency_id"] = partner.with_company(company_id).property_purchase_currency_id.id
-            else:
-                order_vals["currency_id"] = company_id.currency_id.id
-        return order_vals


### PR DESCRIPTION
When the 'use supplier's currency' configuration is selected, it used to create as many POs as different currencies the products in the SO lines had. 
Example:
SO line 1: Product A, currency: EUR
SO line 2: Product B, currency: USD
Supplier's currency: ARS
Created two POs in ARS, one for Product A and one for Product B

Now: It creates only one PO with the supplier's currency.