### PR TITLE
[IMP] purchase_request_ux: Revert OCA behavior on notification messages

### DIFF
--- a/purchase_request_ux/__manifest__.py
+++ b/purchase_request_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Purchase Request UX',
-    'version': "16.0.1.1.0",
+    'version': "16.0.1.2.0",
     'category': 'Purchases',
     'sequence': 14,
     'summary': '',

--- a/purchase_request_ux/models/__init__.py
+++ b/purchase_request_ux/models/__init__.py
@@ -1,1 +1,4 @@
+from . import mail_thread
 from . import purchase_request
+from . import purchase_order
+from . import stock_move_line

--- a/purchase_request_ux/models/mail_thread.py
+++ b/purchase_request_ux/models/mail_thread.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def message_post(self, **kwargs):
+        """Override to support force_subtype_id from context."""
+        # If force_subtype_id comes from context, use it
+        if self.env.context.get("force_subtype_id"):
+            kwargs["subtype_id"] = self.env.ref(self.env.context["force_subtype_id"]).id
+        return super().message_post(**kwargs)

--- a/purchase_request_ux/models/purchase_order.py
+++ b/purchase_request_ux/models/purchase_order.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def _purchase_request_confirm_message(self):
+        """Calling super running parent logic but force mt_comment instead of mt_note subtype for message posting."""
+        return super(
+            PurchaseOrder, self.with_context(force_subtype_id="mail.mt_comment")
+        )._purchase_request_confirm_message()

--- a/purchase_request_ux/models/stock_move_line.py
+++ b/purchase_request_ux/models/stock_move_line.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def allocate(self):
+        """Calling super running parent logic but force mt_comment instead of mt_note subtype for message posting."""
+        return super(StockMoveLine, self.with_context(force_subtype_id="mail.mt_comment")).allocate()


### PR DESCRIPTION
Restore mt_comment notifications instead of mt_note

The OCA commit
https://github.com/oca/purchase-workflow/commit/fcb866c1892422c6bbc7c260e63ccb2cf9fbf775
changed notifications to use `mt_note`, which are not
visible to end users. This restores the previous behavior by forcing
`mt_comment` subtype so that users are properly notified on PR confirmation
and receptions.
