### PR TITLE
[IMP] purchase_ux: ignore incompatible UoM lines

### DIFF
--- a/purchase_ux/models/account_move.py
+++ b/purchase_ux/models/account_move.py
@@ -82,3 +82,12 @@ class AccountMove(models.Model):
 
     def get_product_lines_to_update(self):
         return self.with_company(self.company_id.id).invoice_line_ids.filtered(lambda x: x.product_id and x.price_unit)
+
+    def action_purchase_matching(self):
+        res = super().action_purchase_matching()
+        # mark the action so compute method in the view can apply special filtering
+        if isinstance(res, dict):
+            ctx = dict(res.get("context") or {})
+            ctx["purchase_matching_from_button"] = True
+            res["context"] = ctx
+        return res

--- a/purchase_ux/models/purchase_bill_line_match.py
+++ b/purchase_ux/models/purchase_bill_line_match.py
@@ -37,3 +37,16 @@ class PurchaseBillLineMatch(models.Model):
                 rec.reference_description = rec.pol_id.name
             else:
                 rec.reference_description = rec.display_name
+
+    def _compute_product_uom_qty(self):
+        # Only apply the incompatibility filter when the view was opened
+        # via the purchase matching action (context flag set by the action).
+        if self.env.context.get("purchase_matching_from_button"):
+            for rec in self:
+                if rec.line_uom_id.category_id.id != rec.product_uom_id.category_id.id:
+                    # incompatible categories: ignore this line for matching
+                    rec.product_uom_qty = 0.0
+                else:
+                    rec.product_uom_qty = rec.line_uom_id._compute_quantity(rec.line_qty, rec.product_uom_id)
+        else:
+            return super()._compute_product_uom_qty()


### PR DESCRIPTION
- Add `action_purchase_matching` on `account.move` to set the `purchase_matching_from_button` context flag
- Modify `_compute_product_uom_qty` in `purchase_bill_line_match` to ignore lines with incompatible UoM categories when opened from the purchase matching action
- Preserve previous behavior when context flag is not present

Change note: Al usar la acción de 'purchase matching' desde la factura de proveedor, ahora se marca el contexto para aplicar un filtrado especial en la vista. Las líneas con unidades de medida incompatibles se ignoran durante la búsqueda de coincidencias, mostrando solo las líneas válidas y evitando el error de UoM.