### PR TITLE
[FIX]purchase_ux: prevent matching of lines with incompatible UoM cat…

### DIFF
--- a/purchase_ux/models/purchase_bill_line_match.py
+++ b/purchase_ux/models/purchase_bill_line_match.py
@@ -43,7 +43,11 @@ class PurchaseBillLineMatch(models.Model):
         # via the purchase matching action (context flag set by the action).
         if self.env.context.get("purchase_matching_from_button"):
             for rec in self:
-                if rec.line_uom_id.category_id.id != rec.product_uom_id.category_id.id:
+                if (
+                    not rec.line_uom_id
+                    or not rec.product_uom_id
+                    or not rec.line_uom_id._has_common_reference(rec.product_uom_id)
+                ):
                     # incompatible categories: ignore this line for matching
                     rec.product_uom_qty = 0.0
                 else:


### PR DESCRIPTION
…egories

When matching a bill line to a purchase order line, if the line's UoM is not compatible with the product's UoM, the line should be ignored for matching (quantity set to 0). This prevents issues with mismatched units of measure during the matching process.