### PR TITLE
[IMP] purchase_ux: move skip_upload setting to purchase configuration

### DIFF
--- a/purchase_ux/__manifest__.py
+++ b/purchase_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase UX",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.4.0",
     "category": "Purchases",
     "sequence": 14,
     "summary": "Purchase order improvements: currency change, price updates, invoice controls and menu enhancements",
@@ -41,7 +41,7 @@
         "views/purchase_line_views.xml",
         "views/product_template_views.xml",
         "views/product_supplierinfo_views.xml",
-        "views/res_company_views.xml",
+        "views/res_config_settings_views.xml",
         "views/purchase_bill_line_match_views.xml",
     ],
     "demo": [

--- a/purchase_ux/i18n/es.po
+++ b/purchase_ux/i18n/es.po
@@ -324,11 +324,6 @@ msgid "Product"
 msgstr "Producto"
 
 #. module: purchase_ux
-#: model_terms:ir.ui.view,arch_db:purchase_ux.view_company_form
-msgid "Purchase"
-msgstr ""
-
-#. module: purchase_ux
 #. odoo-python
 #: code:addons/purchase_ux/models/purchase_order_line.py:0
 msgid "Purchase Line"
@@ -400,6 +395,7 @@ msgstr "Establecer como facturado"
 
 #. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_res_company__skip_upload
+#: model:ir.model.fields,field_description:purchase_ux.field_res_config_settings__skip_upload
 msgid "Skip Bill File Upload"
 msgstr ""
 
@@ -422,6 +418,15 @@ msgstr ""
 #: code:addons/purchase_ux/wizards/purchase_order_line_add_to_invoice.py:0
 msgid "This wizard must be called from purchase lines"
 msgstr "El asistente debe ser llamado desde las líneas de compra"
+
+#. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_purchase_order__skip_upload
+#: model:ir.model.fields,help:purchase_ux.field_res_company__skip_upload
+#: model:ir.model.fields,help:purchase_ux.field_res_config_settings__skip_upload
+msgid ""
+"When enabled, bills will be created directly without requiring file upload "
+"in purchase orders."
+msgstr ""
 
 #. module: purchase_ux
 #: model_terms:ir.ui.view,arch_db:purchase_ux.view_purchase_change_currency
@@ -448,14 +453,6 @@ msgstr "Remito"
 #: model:ir.model.fields.selection,name:purchase_ux.selection__purchase_order_line__invoice_status__to_invoice
 msgid "Waiting Invoices"
 msgstr "Esperando facturas"
-
-#. module: purchase_ux
-#: model:ir.model.fields,help:purchase_ux.field_purchase_order__skip_upload
-#: model:ir.model.fields,help:purchase_ux.field_res_company__skip_upload
-msgid ""
-"When enabled, bills will be created directly without requiring file upload "
-"in purchase orders."
-msgstr ""
 
 #. module: purchase_ux
 #: model_terms:ir.ui.view,arch_db:purchase_ux.purchase_order_line_add_to_invoice_form

--- a/purchase_ux/i18n/purchase_ux.pot
+++ b/purchase_ux/i18n/purchase_ux.pot
@@ -306,11 +306,6 @@ msgid "Product"
 msgstr ""
 
 #. module: purchase_ux
-#: model_terms:ir.ui.view,arch_db:purchase_ux.view_company_form
-msgid "Purchase"
-msgstr ""
-
-#. module: purchase_ux
 #. odoo-python
 #: code:addons/purchase_ux/models/purchase_order_line.py:0
 msgid "Purchase Line"
@@ -382,6 +377,7 @@ msgstr ""
 
 #. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_res_company__skip_upload
+#: model:ir.model.fields,field_description:purchase_ux.field_res_config_settings__skip_upload
 msgid "Skip Bill File Upload"
 msgstr ""
 
@@ -401,6 +397,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/purchase_ux/wizards/purchase_order_line_add_to_invoice.py:0
 msgid "This wizard must be called from purchase lines"
+msgstr ""
+
+#. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_purchase_order__skip_upload
+#: model:ir.model.fields,help:purchase_ux.field_res_company__skip_upload
+#: model:ir.model.fields,help:purchase_ux.field_res_config_settings__skip_upload
+msgid ""
+"When enabled, bills will be created directly without requiring file upload "
+"in purchase orders."
 msgstr ""
 
 #. module: purchase_ux
@@ -427,14 +432,6 @@ msgstr ""
 #. module: purchase_ux
 #: model:ir.model.fields.selection,name:purchase_ux.selection__purchase_order_line__invoice_status__to_invoice
 msgid "Waiting Invoices"
-msgstr ""
-
-#. module: purchase_ux
-#: model:ir.model.fields,help:purchase_ux.field_purchase_order__skip_upload
-#: model:ir.model.fields,help:purchase_ux.field_res_company__skip_upload
-msgid ""
-"When enabled, bills will be created directly without requiring file upload "
-"in purchase orders."
 msgstr ""
 
 #. module: purchase_ux

--- a/purchase_ux/models/__init__.py
+++ b/purchase_ux/models/__init__.py
@@ -4,7 +4,8 @@
 ##############################################################################
 from . import account_move
 from . import purchase_order
+from . import res_company
+from . import res_config_settings
 from . import purchase_order_line
 from . import product_template
-from . import res_company
 from . import purchase_bill_line_match

--- a/purchase_ux/models/res_config_settings.py
+++ b/purchase_ux/models/res_config_settings.py
@@ -1,0 +1,16 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    skip_upload = fields.Boolean(
+        related="company_id.skip_upload",
+        readonly=False,
+        string="Skip Bill File Upload",
+        help="When enabled, bills will be created directly without requiring file upload in purchase orders.",
+    )

--- a/purchase_ux/views/res_company_views.xml
+++ b/purchase_ux/views/res_company_views.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<odoo/>

--- a/purchase_ux/views/res_company_views.xml
+++ b/purchase_ux/views/res_company_views.xml
@@ -1,17 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo>
-
-    <record id="view_company_form" model="ir.ui.view">
-        <field name="name">res.company.form.inherit.purchase.ux</field>
-        <field name="model">res.company</field>
-        <field name="inherit_id" ref="base.view_company_form"/>
-        <field name="arch" type="xml">
-            <field name="color" position="after">
-                <group string="Purchase">
-                    <field name="skip_upload"/>
-                </group>
-            </field>
-        </field>
-    </record>
-
-</odoo>
+<odoo/>

--- a/purchase_ux/views/res_config_settings_views.xml
+++ b/purchase_ux/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form_purchase_ux" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.purchase_ux</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="purchase.res_config_settings_view_form_purchase"/>
+        <field name="arch" type="xml">
+            <xpath expr="//block[@name='invoicing_settings_container']" position="inside">
+                <setting id="skip_upload" company_dependent="1"
+                    help="When enabled, bills will be created directly without requiring file upload in purchase orders.">
+                    <field name="skip_upload"/>
+                </setting>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## Summary

- Moves the "Skip Bill File Upload" setting from the company form to the **Purchase settings page** (Invoicing section), following Odoo's standard UX pattern for per-company configuration
- Adds `res.config.settings` extension with `company_dependent="1"` so the building icon appears automatically in multi-company setups
- `res.company.skip_upload` field unchanged (still default `True`); only the configuration surface moved

## Test plan

- [ ] Settings → Purchase → Invoicing: check "Skip Bill File Upload" checkbox appears with building icon
- [ ] Toggle off and confirm that the file uploader widget appears again on confirmed purchase orders
- [ ] Toggle on and confirm "Create Bill" button appears directly without file uploader
- [ ] Verify the setting is no longer visible in Settings → Companies → company form

closes #118690

🤖 Generated with [Claude Code](https://claude.com/claude-code)