### PR TITLE
[FIX] purchase_ux: add product_id and selected_seller_id to name compute depends

### DIFF
--- a/purchase_ux/models/purchase_order_line.py
+++ b/purchase_ux/models/purchase_order_line.py
@@ -154,6 +154,7 @@ class PurchaseOrderLine(models.Model):
         for rec in self:
             rec.invoice_qty = rec.qty_to_invoice + rec.invoice_qty
 
+    @api.depends("product_id", "selected_seller_id")
     def _compute_price_unit_and_date_planned_and_name(self):
         """Basicamente modificamos dos cosas:
         a) si la compra esta confirmada y cambiamos cantidades u otro dato, que no se actualice ni precio,


### PR DESCRIPTION
## Summary

- In v19, `_compute_price_unit_and_date_planned_and_name` (which sets the `name`/Description field on PO lines) lacked `product_id` and `selected_seller_id` in its `@api.depends`.
- OWL did not know to re-render the Description column when the product changed, leaving it blank until the next repaint (e.g. Alt+Tab).
- The backend was already computing the correct value via the legacy `@api.onchange('product_id')`, but the list widget never received the signal to update.
- Fix: extend the `@api.depends` in the `purchase_ux` override with `product_id` and `selected_seller_id` so OWL triggers the recompute and re-renders the field immediately on product selection.

## Test plan

- [ ] Open a draft PO, add a new line and select a product that has a vendor with a reference code — Description should auto-fill immediately (no save or focus-change required).
- [ ] Confirm that changing the product on an existing draft line updates the Description correctly.
- [ ] Confirm that changing the product on a confirmed PO line does **not** update Description (existing `purchase_ux` guard: `state not in ['purchase', 'done']`).
- [ ] Confirm price and date_planned still compute correctly on product selection.