### PR TITLE
[FIX] purchase_stock_ux: corregir descripcion de producto en lineas nuevas de compra

### DIFF
--- a/purchase_stock_ux/models/purchase_order_line.py
+++ b/purchase_stock_ux/models/purchase_order_line.py
@@ -235,8 +235,9 @@ class PurchaseOrderLine(models.Model):
     def _compute_price_unit_and_date_planned_and_name(self):
         # Esto lo hacemos por un caso raro de cancelacion de remanentes,
         # Odoo cambia el price_unit del move antes de commitear a 0 la qty y hace que cree contraentregas
+        # El filtro aplica solo a líneas confirmadas/hechas: en borradores qty=0 es válido (línea nueva)
         all_lines = self
         for line in all_lines:
-            if not line.product_qty:
+            if not line.product_qty and line.state in ("purchase", "done"):
                 all_lines -= line
         super(PurchaseOrderLine, all_lines)._compute_price_unit_and_date_planned_and_name()

--- a/purchase_ux/__manifest__.py
+++ b/purchase_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase UX",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Purchases",
     "sequence": 14,
     "summary": "Purchase order improvements: currency change, price updates, invoice controls and menu enhancements",

--- a/purchase_ux/views/purchase_order_views.xml
+++ b/purchase_ux/views/purchase_order_views.xml
@@ -45,10 +45,15 @@
             <widget name="purchase_file_uploader" position="replace">
                 <widget name="purchase_file_uploader" invisible="state != 'purchase' or skip_upload"/>
                 <button name="action_create_invoice" type="object" string="Create Bill"
-                    invisible="state != 'purchase' or not skip_upload"
+                    invisible="state != 'purchase' or not skip_upload or invoice_status in ('no', 'invoiced')"
                     class="oe_highlight"
-                    data-hotkey="i"/>
-            </widget>
+                    data-hotkey="i"
+                />
+                <button name="action_create_invoice" string="Create Bill" type="object"
+                    invisible="state != 'purchase' or not skip_upload or invoice_status not in ('no', 'invoiced') or not order_line"
+                    data-hotkey="w"
+                />
+                </widget>
         </field>
     </record>
 


### PR DESCRIPTION
## Problema

Al crear una línea en una Solicitud de Cotización / Orden de Compra y seleccionar un producto, el campo **Descripción** quedaba vacío hasta hacer un refresh manual de la pantalla (ej. Alt+Tab).

## Causa

En `purchase_stock_ux`, el override de `_compute_price_unit_and_date_planned_and_name` excluía del `super()` **todas** las líneas con `product_qty == 0`. El problema: una línea nueva tiene `product_qty = 0` por defecto hasta que el usuario ingresa la cantidad, por lo que el compute nunca se ejecutaba para ella y el campo `name` no se poblaba.

## Fix

El filtro existe para evitar contraentregas al cancelar remanentes (Odoo puede setear `price_unit = 0` en el move antes de commitear `qty = 0`). Ese escenario solo aplica a órdenes ya **confirmadas o hechas** (`state in ('purchase', 'done')`).

Se acota la condición para excluir solo esas líneas, permitiendo que las líneas en borrador con `qty = 0` pasen al `super()` y obtengan su `name` correctamente.

```python
# Antes
if not line.product_qty:
    all_lines -= line

# Después
if not line.product_qty and line.state in ("purchase", "done"):
    all_lines -= line
```

## Test plan

- Crear una nueva Solicitud de Cotización
- Agregar una línea y seleccionar un producto
- Verificar que el campo **Descripción** se autocompleta sin necesidad de cambiar de ventana
- Confirmar la orden y verificar que el precio y descripción no cambian al editar cantidades