### PR TITLE
[IMP] purchase_ux: include vendor child contacts in purchase bill matching

### DIFF
--- a/purchase_ux/models/account_move.py
+++ b/purchase_ux/models/account_move.py
@@ -85,9 +85,16 @@ class AccountMove(models.Model):
 
     def action_purchase_matching(self):
         res = super().action_purchase_matching()
-        # mark the action so compute method in the view can apply special filtering
         if isinstance(res, dict):
             ctx = dict(res.get("context") or {})
             ctx["purchase_matching_from_button"] = True
             res["context"] = ctx
+            # Include PO lines from vendor child contacts (same commercial partner)
+            commercial_partner = self.partner_id | self.partner_id.commercial_partner_id
+            res["domain"] = [
+                ("partner_id.commercial_partner_id", "in", commercial_partner.ids)
+                if isinstance(c, (list, tuple)) and c[0] == "partner_id"
+                else c
+                for c in res.get("domain", [])
+            ]
         return res


### PR DESCRIPTION
## Summary

When pressing the "Associate purchase lines" button on a vendor invoice, the matching dialog now also shows PO lines where the vendor is a child contact (same commercial partner) of the invoice's vendor.

Previously the domain filtered by `partner_id IN (vendor, commercial_partner)`, which excluded POs made to child contacts (e.g. sub-vendors sharing the same parent company). The fix replaces that condition with `partner_id.commercial_partner_id IN (vendor, commercial_partner)`, which traverses the hierarchy and includes all child contacts.

**Files changed:** `purchase_ux/models/account_move.py`

Task: https://www.adhoc.inc/odoo/action-197/69018