### PR TITLE
[IMP] purchase_ux: exclude force-invoiced POs from purchase matching view

### DIFF
--- a/purchase_ux/models/purchase_bill_line_match.py
+++ b/purchase_ux/models/purchase_bill_line_match.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from odoo import api, fields, models
+from odoo.tools import SQL
 
 
 class PurchaseBillLineMatch(models.Model):
@@ -37,6 +38,19 @@ class PurchaseBillLineMatch(models.Model):
                 rec.reference_description = rec.pol_id.name
             else:
                 rec.reference_description = rec.display_name
+
+    @property
+    def _table_query(self):
+        return SQL(
+            """
+            SELECT base.* FROM (%s) AS base
+            WHERE base.purchase_order_id IS NULL
+               OR base.purchase_order_id NOT IN (
+                   SELECT id FROM purchase_order WHERE force_invoiced_status = 'invoiced'
+               )
+            """,
+            super()._table_query,
+        )
 
     def _compute_product_uom_qty(self):
         # Only apply the incompatibility filter when the view was opened


### PR DESCRIPTION
## Summary

When a purchase order has `force_invoiced_status = 'invoiced'` (manually forced as fully invoiced via the `button_set_invoiced` mechanism in `purchase_ux`), its lines were still appearing in the **Asociar lineas de compra** smart button on vendor bills.

This happened because `purchase.bill.line.match` is a SQL view built from `_select_po_line()`, which filters by `qty_to_invoice != 0` and `product_qty > qty_invoiced` — raw DB columns that are **not** updated when `force_invoiced_status` is set (only `qty_to_invoice` is zeroed out via `button_set_invoiced`, but `force_invoiced_status` is a separate field for the non-destructive force path).

## Change

Override `_select_po_line()` in `purchase_ux`'s `PurchaseBillLineMatch` to wrap the parent query and exclude any purchase order where `force_invoiced_status = 'invoiced'`.

## Test plan

1. Confirm a purchase order and set it as force-invoiced (`force_invoiced_status = 'invoiced'`).
2. Open a draft vendor bill for the same partner.
3. Click the **Asociar lineas de compra** smart button.
4. Verify the force-invoiced PO lines do **not** appear in the matching view.
5. Verify that PO lines from normal (non-force-invoiced) orders still appear as expected.