### PR TITLE
[FIX] purchase_ux: fix currency rate precision in change currency wizard

### DIFF
--- a/purchase_ux/wizards/purchase_change_currency.py
+++ b/purchase_ux/wizards/purchase_change_currency.py
@@ -18,6 +18,7 @@ class PurchaseChangeCurrency(models.TransientModel):
     )
     currency_rate = fields.Float(
         required=True,
+        digits=(16, 6),
         help="Select a currency rate to apply on the purchase order",
     )
 
@@ -36,14 +37,11 @@ class PurchaseChangeCurrency(models.TransientModel):
         else:
             if self.currency_id == purchase_order.currency_id:
                 raise UserError(_("Old Currency And New Currency can not be the same"))
-            currency = purchase_order.currency_id.with_context(
-                date=purchase_order.date_order or fields.Date.context_today(self)
-            )
-            self.currency_rate = currency._convert(
-                1.0,
-                self.currency_id,
-                purchase_order.company_id,
-                purchase_order.date_order or fields.Date.context_today(self),
+            self.currency_rate = self.env["res.currency"]._get_conversion_rate(
+                from_currency=purchase_order.currency_id,
+                to_currency=self.currency_id,
+                company=purchase_order.company_id,
+                date=purchase_order.date_order or fields.Date.context_today(self),
             )
 
     def change_currency(self):


### PR DESCRIPTION
## Summary

- `_convert(1.0, to_currency)` rounds the result to the destination currency's decimal places (e.g. USD = 2), producing `0.00` when converting from ARS → USD and zeroing out all line prices.
- Fix by using `_get_conversion_rate()` (raw rate, no rounding) — same approach already used by `account_ux`.
- Added `digits=(16, 6)` to `currency_rate` field so the rate is stored and displayed with enough precision.

## Test plan

- [ ] Crear OC con moneda USD, agregar línea con precio
- [ ] Cambiar moneda a ARS → precio se convierte correctamente
- [ ] Cambiar moneda de vuelta a USD → tasa aparece con 6 decimales (ej. `0.000667`), precio se recalcula correctamente (no queda en 0)

Closes #120310