### PR TITLE
[FIX] purchase_stock_ux: exclude fully-returned lines from vendor bill

### DIFF
--- a/purchase_stock_ux/models/purchase_order.py
+++ b/purchase_stock_ux/models/purchase_order.py
@@ -4,6 +4,7 @@
 ##############################################################################
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_is_zero
 
 
 class PurchaseOrder(models.Model):
@@ -60,6 +61,31 @@ class PurchaseOrder(models.Model):
                 )
             else:
                 raise UserError(_('Only users with "%s" can Set Received manually') % (group.name))
+
+    def action_create_invoice(self, attachment_ids=False):
+        """Drop the zero-quantity lines Odoo 19 leaves on the draft vendor bill.
+
+        Odoo 19's ``action_create_invoice`` iterates over every ``order_line``
+        without filtering by ``qty_to_invoice`` (the old ``_get_invoiceable_lines``
+        is gone). Our ``_compute_qty_invoiced`` subtracts ``qty_returned``, so a
+        fully-returned line has ``qty_to_invoice = 0`` and core still adds it to
+        the bill as a zero-quantity line.
+
+        We let ``super`` build the invoice and clean it up afterwards instead of
+        reimplementing the whole method, so we don't bypass other overrides of it
+        in the MRO (e.g. ``purchase_force_invoiced``, which skips invoicing on
+        force-invoiced orders). Sections, notes and down payment lines are kept.
+        """
+        invoices_before = self.invoice_ids
+        action = super().action_create_invoice(attachment_ids=attachment_ids)
+        precision = self.env["decimal.precision"].precision_get("Product Unit")
+        new_invoices = self.invoice_ids - invoices_before
+        new_invoices.invoice_line_ids.filtered(
+            lambda aml: aml.display_type == "product"
+            and not aml.is_downpayment
+            and float_is_zero(aml.quantity, precision_digits=precision)
+        ).unlink()
+        return action
 
     def button_cancel(self):
         self = self.with_context(cancel_from_order=True)

--- a/purchase_stock_ux/tests/test_purchase_order.py
+++ b/purchase_stock_ux/tests/test_purchase_order.py
@@ -1,5 +1,6 @@
 from odoo import Command
 from odoo.addons.purchase_stock.tests.common import PurchaseTestCommon
+from odoo.tools.float_utils import float_is_zero
 
 
 class TestPurchaseOrder(PurchaseTestCommon):
@@ -30,3 +31,159 @@ class TestPurchaseOrder(PurchaseTestCommon):
         )
 
         cls.purchase_order.button_confirm()
+
+    def _create_return_for_product(self, picking, product, qty, to_refund=True):
+        """Return `qty` units of `product` from a validated picking."""
+        return_wiz = (
+            self.env["stock.return.picking"].with_context(active_id=picking.id, active_model="stock.picking").create({})
+        )
+        for line in return_wiz.product_return_moves:
+            if line.product_id == product:
+                line.quantity = qty
+                line.to_refund = to_refund
+            else:
+                line.quantity = 0
+        return_picking = return_wiz._create_return()
+        return_picking.move_ids.quantity = qty
+        return_picking.with_context(skip_backorder=True).button_validate()
+        return return_picking
+
+    def test_invoice_excludes_fully_returned_lines(self):
+        """Mixed PO: invoiceable line + fully-returned line → only invoiceable line in invoice."""
+        product2 = self.env["product.product"].create(
+            {
+                "name": "Product 2 Storable",
+                "is_storable": True,
+                "purchase_method": "purchase",
+            }
+        )
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 10,
+                            "price_unit": 50,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": product2.id,
+                            "product_qty": 5,
+                            "price_unit": 20,
+                        }
+                    ),
+                ],
+            }
+        )
+        po.button_confirm()
+
+        picking = po.picking_ids
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+        picking.with_context(skip_backorder=True).button_validate()
+
+        # Fully return only product2 (line 2)
+        self._create_return_for_product(picking, product2, qty=5)
+
+        line2 = po.order_line.filtered(lambda l: l.product_id == product2)
+        self.assertTrue(
+            float_is_zero(line2.qty_to_invoice, precision_digits=2),
+            "Fully returned line must have qty_to_invoice = 0",
+        )
+
+        invoice = self.env["account.move"].browse(po.action_create_invoice()["res_id"])
+        product_lines = invoice.invoice_line_ids.filtered(lambda l: l.display_type == "product")
+        self.assertEqual(len(product_lines), 1, "Invoice must not include the fully-returned line")
+        self.assertEqual(product_lines.product_id, self.product)
+
+    def test_invoice_partial_return_no_regression(self):
+        """Partial return → invoice for the remaining net quantity, no zero lines."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 10,
+                            "price_unit": 50,
+                        }
+                    ),
+                ],
+            }
+        )
+        po.button_confirm()
+
+        picking = po.picking_ids
+        picking.move_ids.quantity = 10
+        picking.with_context(skip_backorder=True).button_validate()
+
+        self._create_return_for_product(picking, self.product, qty=4)
+
+        line = po.order_line
+        self.assertAlmostEqual(line.qty_to_invoice, 6.0, places=2)
+
+        invoice = self.env["account.move"].browse(po.action_create_invoice()["res_id"])
+        product_lines = invoice.invoice_line_ids.filtered(lambda l: l.display_type == "product")
+        self.assertEqual(len(product_lines), 1)
+        self.assertAlmostEqual(product_lines.quantity, 6.0, places=2)
+
+    def test_invoice_keeps_note_lines(self):
+        """Note lines also have qty_to_invoice = 0 but must stay on the bill."""
+        product2 = self.env["product.product"].create(
+            {
+                "name": "Product 2 Storable",
+                "is_storable": True,
+                "purchase_method": "purchase",
+            }
+        )
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 10,
+                            "price_unit": 50,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "display_type": "line_note",
+                            "name": "Handle with care",
+                            "product_id": False,
+                            "product_qty": 0.0,
+                            "product_uom_id": False,
+                            "price_unit": 0.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": product2.id,
+                            "product_qty": 5,
+                            "price_unit": 20,
+                        }
+                    ),
+                ],
+            }
+        )
+        po.button_confirm()
+
+        picking = po.picking_ids
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+        picking.with_context(skip_backorder=True).button_validate()
+
+        # Fully return product2 so its line drops to qty_to_invoice = 0
+        self._create_return_for_product(picking, product2, qty=5)
+
+        invoice = self.env["account.move"].browse(po.action_create_invoice()["res_id"])
+        product_lines = invoice.invoice_line_ids.filtered(lambda l: l.display_type == "product")
+        note_lines = invoice.invoice_line_ids.filtered(lambda l: l.display_type == "line_note")
+        self.assertEqual(len(product_lines), 1, "Only the invoiceable product line must remain")
+        self.assertEqual(product_lines.product_id, self.product)
+        self.assertEqual(note_lines.name, "Handle with care", "Note lines must be kept on the bill")


### PR DESCRIPTION
## Summary

When creating a vendor bill from a PO that has lines with `qty_to_invoice = 0`
(fully returned with `to_refund=True`), the draft invoice included those lines
with quantity 0. The user had to delete them manually.

**Root cause:** Odoo 19 removed the old `_get_invoiceable_lines` filter from
`action_create_invoice` and now iterates all `order_line` unconditionally.
`purchase_stock_ux` overrides `_compute_qty_invoiced` to subtract `qty_returned`
from `qty_to_invoice`, so fully-returned lines produce `qty_to_invoice = 0` and
still end up as invoice lines with that quantity.

**Fix:** Override `action_create_invoice` in `purchase_stock_ux` to skip lines
where `float_is_zero(qty_to_invoice)` and that are not sections/notes or
downpayments. Section headers are preserved: they are only added when a
subsequent invoiceable line consumes them, so empty sections are also dropped.

## Test plan

Two new tests in `purchase_stock_ux/tests/test_purchase_order.py`:

- `test_invoice_excludes_fully_returned_lines`: PO with 2 lines (L0 invoiceable,
  L1 fully returned) → invoice must contain only L0 with no zero-qty lines.
- `test_invoice_partial_return_no_regression`: single line, partial return (4/10)
  → invoice with 1 line at quantity 6 (no regression).

Covers acceptance criteria:
- Mixed PO (invoiceable + fully-returned line) → only invoiceable line in bill
- Partial return → bill for the net (no regression)
- Both `purchase_method` policies produce `qty_to_invoice = 0` for fully-returned
  lines, so the filter works for both "Ordered quantities" and "Received quantities"

Internal task: https://www.adhoc.inc/odoo/knowledge/180/project.task/69417