### PR TITLE
[ADD] purchase_stock_ux: mass cancellation of remaining qty to receive

### DIFF
--- a/purchase_stock_ux/__manifest__.py
+++ b/purchase_stock_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase Stock UX",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "category": "Purchases",
     "sequence": 14,
     "summary": "",
@@ -33,10 +33,12 @@
         "stock_ux",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "views/purchase_order_views.xml",
         "views/purchase_line_views.xml",
         "views/stock_move_views.xml",
         "wizards/res_config_settings_views.xml",
+        "wizards/purchase_order_cancel_remaining.xml",
     ],
     "demo": [],
     "installable": True,

--- a/purchase_stock_ux/security/ir.model.access.csv
+++ b/purchase_stock_ux/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_purchase_order_cancel_remaining_wizard,access_purchase_order_cancel_remaining_wizard,model_purchase_order_cancel_remaining,base.group_user,1,1,1,0

--- a/purchase_stock_ux/wizards/__init__.py
+++ b/purchase_stock_ux/wizards/__init__.py
@@ -3,3 +3,4 @@
 # directory
 ##############################################################################
 from . import res_config_settings
+from . import purchase_order_cancel_remaining

--- a/purchase_stock_ux/wizards/purchase_order_cancel_remaining.py
+++ b/purchase_stock_ux/wizards/purchase_order_cancel_remaining.py
@@ -1,0 +1,19 @@
+from odoo import api, fields, models
+
+
+class PurchaseOrderCancelRemaining(models.TransientModel):
+    _name = "purchase.order.cancel.remaining"
+    _description = "Purchase Order Cancel Remaining"
+
+    purchase_order_line_ids = fields.Many2many(
+        "purchase.order.line", required=True, default=lambda self: self.default_purchase_order_line_ids()
+    )
+
+    @api.model
+    def default_purchase_order_line_ids(self):
+        return self.env["purchase.order"].browse(self.env.context.get("active_ids", [])).mapped("order_line")
+
+    def action_confirm(self):
+        self.purchase_order_line_ids.filtered(
+            lambda x: x.receipt_status in ("pending", "partial")
+        ).with_context(cancel_from_order=True).button_cancel_remaining()

--- a/purchase_stock_ux/wizards/purchase_order_cancel_remaining.py
+++ b/purchase_stock_ux/wizards/purchase_order_cancel_remaining.py
@@ -14,6 +14,6 @@ class PurchaseOrderCancelRemaining(models.TransientModel):
         return self.env["purchase.order"].browse(self.env.context.get("active_ids", [])).mapped("order_line")
 
     def action_confirm(self):
-        self.purchase_order_line_ids.filtered(
-            lambda x: x.receipt_status in ("pending", "partial")
-        ).with_context(cancel_from_order=True).button_cancel_remaining()
+        self.purchase_order_line_ids.filtered(lambda x: x.receipt_status in ("pending", "partial")).with_context(
+            cancel_from_order=True
+        ).button_cancel_remaining()

--- a/purchase_stock_ux/wizards/purchase_order_cancel_remaining.xml
+++ b/purchase_stock_ux/wizards/purchase_order_cancel_remaining.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="purchase_order_cancel_remaining_form" model="ir.ui.view">
+        <field name="name">purchase.order.cancel.remaining.form</field>
+        <field name="model">purchase.order.cancel.remaining</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="purchase_order_line_ids" invisible="1"/>
+                <div>
+                    'Do you want to cancel remaining quantities to receive for these orders? This can´t be undone'
+                </div>
+                <footer>
+                    <button string="Confirm" name="action_confirm" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_purchase_order_massive_cancel_wizard" model="ir.actions.act_window">
+        <field name="name">Mass cancellation of remaining quantities</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="res_model">purchase.order.cancel.remaining</field>
+        <field name="binding_model_id" ref="purchase.model_purchase_order"/>
+    </record>
+</odoo>


### PR DESCRIPTION
## What

Adds a wizard to cancel the **remaining quantity to receive** on all lines of one or more purchase orders in a single operation.

- New transient model `purchase.order.cancel.remaining` (+ form with confirmation).
- Exposed as a contextual action ("Mass cancellation of remaining quantities") bound to `purchase.order`, available from the list and form action menu.
- It collects the order lines whose `receipt_status` is `pending` or `partial` and applies the existing per-line `button_cancel_remaining()`.

## Why

There was no way to cancel only the remaining qty to receive of a PO when a vendor delivers partially and the rest won't arrive — the order stayed open indefinitely or had to be cancelled and recreated. The per-line `button_cancel_remaining` already existed; this adds the order-level (mass) counterpart, mirroring `sale.order.cancel.remaining` in `sale_stock_ux`.

Out of scope: remaining qty **to invoice** (only qty to receive is handled).

## How it works

Reuses `button_cancel_remaining()`, which sets the line `product_qty` to `qty_received + qty_returned`; Odoo then cancels the pending moves. Lines already fully received are ignored, and each cancelled line is logged in the chatter.

## Test plan

1. Confirm a PO with several lines.
2. Receive one line partially, leave the rest pending.
3. Order action menu → **Mass cancellation of remaining quantities** → Confirm.
4. Expected: all lines with remaining go to `receipt_status = full` (ordered qty drops to received qty), pending receptions are cancelled, and the chatter logs the qty change per line. Already-received and already-invoiced quantities are untouched.

Task 52215.
