### PR TITLE
[FIX] purchase_stock_ux: exclude subcontract receipts from returned qty

### DIFF
--- a/purchase_stock_ux/models/purchase_order_line.py
+++ b/purchase_stock_ux/models/purchase_order_line.py
@@ -159,9 +159,8 @@ class PurchaseOrderLine(models.Model):
     def _compute_qty_returned(self):
         for line in self:
             qty = 0.0
-            for move in line.move_ids.filtered(
-                lambda m: m.state == "done" and m.location_id.usage != "supplier" and m.to_refund
-            ):
+            # Count only real vendor returns (excludes the subcontract receipt move).
+            for move in line.move_ids.filtered(lambda m: m.state == "done" and m.to_refund and m._is_purchase_return()):
                 qty += move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom_id)
             line.qty_returned = qty
 

--- a/purchase_stock_ux/tests/test_purchase_order.py
+++ b/purchase_stock_ux/tests/test_purchase_order.py
@@ -131,6 +131,83 @@ class TestPurchaseOrder(PurchaseTestCommon):
         self.assertEqual(len(product_lines), 1)
         self.assertAlmostEqual(product_lines.quantity, 6.0, places=2)
 
+    def test_real_return_sets_qty_returned(self):
+        """A genuine refundable return to the vendor must feed qty_returned."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 10,
+                            "price_unit": 50,
+                        }
+                    ),
+                ],
+            }
+        )
+        po.button_confirm()
+
+        picking = po.picking_ids
+        picking.move_ids.quantity = 10
+        picking.with_context(skip_backorder=True).button_validate()
+
+        self._create_return_for_product(picking, self.product, qty=4)
+
+        self.assertAlmostEqual(po.order_line.qty_returned, 4.0, places=2)
+
+    def test_subcontract_receipt_not_flagged_as_returned(self):
+        """Ticket 121292: a ``to_refund`` move that is NOT a purchase return
+        (e.g. the subcontracting receipt when the MO is closed before validating
+        the receipt) must not inflate qty_returned, otherwise the line drops to
+        qty_to_invoice = 0 and the received goods cannot be billed."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 10,
+                            "price_unit": 50,
+                        }
+                    ),
+                ],
+            }
+        )
+        po.button_confirm()
+
+        picking = po.picking_ids
+        picking.move_ids.quantity = 10
+        picking.with_context(skip_backorder=True).button_validate()
+        line = po.order_line
+
+        # Mimic the subcontracting receipt move: done, to_refund, internal source
+        # and destination (no return to supplier, no origin_returned_move_id), so
+        # ``_is_purchase_return()`` is False even though ``to_refund`` is True.
+        internal_loc = picking.location_dest_id
+        bogus_move = self.env["stock.move"].create(
+            {
+                "product_id": self.product.id,
+                "product_uom_qty": 10,
+                "product_uom": self.product.uom_id.id,
+                "location_id": internal_loc.id,
+                "location_dest_id": internal_loc.id,
+                "to_refund": True,
+                "purchase_line_id": line.id,
+            }
+        )
+        bogus_move.write({"state": "done"})
+
+        self.assertFalse(
+            bogus_move._is_purchase_return(),
+            "Sanity check: the crafted move must not be a purchase return",
+        )
+        line.invalidate_recordset(["qty_returned", "qty_to_invoice"])
+        self.assertAlmostEqual(line.qty_returned, 0.0, places=2, msg="Subcontract receipt must not count as returned")
+        self.assertAlmostEqual(line.qty_to_invoice, 10.0, places=2, msg="Received goods must stay invoiceable")
+
     def test_invoice_keeps_note_lines(self):
         """Note lines also have qty_to_invoice = 0 but must stay on the bill."""
         product2 = self.env["product.product"].create(


### PR DESCRIPTION
## Problem

`purchase.order.line._compute_qty_returned` counted **any** done move with `to_refund=True` whose source location was not a supplier as "returned" (`location_id.usage != 'supplier' and to_refund`).

In a subcontracting flow, when the manufacturing order is closed **before** the purchase receipt is validated, the subcontract receipt move is created with `to_refund=True` and an internal source location (the subcontracting location), so it matched that filter and inflated `qty_returned`.

Because `qty_returned` feeds `qty_to_invoice = product_qty - qty_invoiced - qty_returned`, a fully-received line ended up with `qty_to_invoice = 0` and the received goods could not be billed.

## Fix

Delegate the "is this a return?" decision to core's `stock.move._is_purchase_return()` (which `mrp_subcontracting_purchase` / `mrp_subcontracting_dropshipping` already extend) instead of the hand-rolled `location_id.usage` check. The subcontract receipt move is not a purchase return — its `location_dest_id` is internal and it has no `origin_returned_move_id` — so it stops being counted. This matches how core itself detects returns in `_prepare_qty_received` / `_get_outgoing_incoming_moves`.

The fix is order-independent: `qty_returned` is now correct whether the receipt is validated before or after closing the MO.

## Test plan

Added non-regression tests in `purchase_stock_ux/tests/test_purchase_order.py`:

- `test_real_return_sets_qty_returned` — a genuine refundable vendor return still feeds `qty_returned`.
- `test_subcontract_receipt_not_flagged_as_returned` — a `to_refund` move that is not a purchase return leaves `qty_returned = 0` and keeps `qty_to_invoice` intact.

Local run: `0 failed, 0 error(s) of 6 tests` for `--test-tags /purchase_stock_ux`.

Internal ref: helpdesk #121292.
