### PR TITLE
[ADD] purchase_order_type_ux: lock on confirmation per order type

### DIFF
--- a/purchase_order_type_ux/README.rst
+++ b/purchase_order_type_ux/README.rst
@@ -17,6 +17,8 @@ Purchase Order Type UX
 On purchase order type:
 
 #. Adds to the purchase order type the report partner, the project, the billing journal and the billing policy.
+#. Adds a per-type "Lock on Confirmation" flag that locks orders of that type when they are approved. It is
+   additive to the global "Lock Confirmed Orders" setting, which always prevails.
 
 Installation
 ============

--- a/purchase_order_type_ux/__manifest__.py
+++ b/purchase_order_type_ux/__manifest__.py
@@ -20,7 +20,7 @@
 
 {
     "name": "Purchase Order Type UX",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "category": "Purchases",
     "sequence": 14,
     "summary": "",
@@ -31,6 +31,7 @@
     "depends": ["purchase_stock_ux", "l10n_ar_purchase", "purchase_order_type", "account_multicompany_ux"],
     "data": [
         "views/purchase_order_type_views.xml",
+        "views/res_config_settings_views.xml",
         "report/purchase_quotation_templates.xml",
     ],
     "installable": True,

--- a/purchase_order_type_ux/i18n/es.po
+++ b/purchase_order_type_ux/i18n/es.po
@@ -53,6 +53,11 @@ msgid "Journal Entry"
 msgstr "Asiento contable"
 
 #. module: purchase_order_type_ux
+#: model:ir.model.fields,field_description:purchase_order_type_ux.field_purchase_order_type__set_locked_on_confirmation
+msgid "Lock on Confirmation"
+msgstr "Bloquear al confirmar"
+
+#. module: purchase_order_type_ux
 #: model:ir.model.fields.selection,name:purchase_order_type_ux.selection__purchase_order_type__purchase_method__purchase
 msgid "On ordered quantities"
 msgstr ""

--- a/purchase_order_type_ux/models/purchase_order.py
+++ b/purchase_order_type_ux/models/purchase_order.py
@@ -23,6 +23,17 @@ class PurchaseOrder(models.Model):
             if order.order_type.fiscal_position_id:
                 order.fiscal_position_id = order.order_type.fiscal_position_id
 
+    def button_approve(self, force=False):
+        res = super().button_approve(force=force)
+        # En compras el "bloqueo" es state == 'done' (no hay campo locked como en ventas). El lock
+        # global del core ya lo hace acá para po_lock == 'lock'; lo replicamos por tipo de forma
+        # aditiva: solo afectamos órdenes recién aprobadas (state 'purchase'), nunca las que siguen
+        # 'to approve' por doble validación pendiente.
+        self.filtered(lambda o: o.order_type.set_locked_on_confirmation and o.state == "purchase").write(
+            {"state": "done"}
+        )
+        return res
+
     def _prepare_invoice(self):
         if not self.order_type.journal_id:
             return super()._prepare_invoice()

--- a/purchase_order_type_ux/models/purchase_order_type.py
+++ b/purchase_order_type_ux/models/purchase_order_type.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2015 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class PurchaseOrderType(models.Model):
@@ -43,3 +43,21 @@ class PurchaseOrderType(models.Model):
         help="If you choose a fiscal position then this fiscal positioon would be used as default instead of the "
         "automatically detected or setted on the partner",
     )
+    set_locked_on_confirmation = fields.Boolean(
+        string="Lock on Confirmation",
+        help="If enabled, purchase orders of this type are automatically locked when they are approved,"
+        " preventing further edits. This is additive to the global 'Lock Confirmed Orders' setting: when that"
+        " setting is on, every confirmed order is locked regardless of this flag, and the global setting prevails.",
+    )
+    lock_confirmed_po_setting = fields.Boolean(
+        compute="_compute_lock_confirmed_po_setting",
+        help="Technical field: True when the global 'Lock Confirmed Orders' setting is enabled for this type's"
+        " company. Analogous to sale_order_type_automation's 'auto_done_setting', it hides the per-type"
+        " 'Lock on Confirmation' flag while the global setting prevails, since the flag would then be irrelevant.",
+    )
+
+    @api.depends("company_id")
+    def _compute_lock_confirmed_po_setting(self):
+        for rec in self:
+            company = rec.company_id or self.env.company
+            rec.lock_confirmed_po_setting = company.sudo().po_lock == "lock"

--- a/purchase_order_type_ux/tests/__init__.py
+++ b/purchase_order_type_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_purchase_order_type_ux

--- a/purchase_order_type_ux/tests/test_purchase_order_type_ux.py
+++ b/purchase_order_type_ux/tests/test_purchase_order_type_ux.py
@@ -1,0 +1,94 @@
+# Copyright 2026 ADHOC SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import Command
+from odoo.addons.purchase_stock.tests.common import PurchaseTestCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseOrderTypeLock(PurchaseTestCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        # El lock global arranca apagado para aislar el efecto del flag por tipo.
+        cls.company.po_lock = "edit"
+        cls.vendor = cls.env["res.partner"].create({"name": "Test Vendor"})
+        cls.type_lock = cls.env["purchase.order.type"].create(
+            {"name": "Locking Type", "set_locked_on_confirmation": True}
+        )
+        cls.type_no_lock = cls.env["purchase.order.type"].create(
+            {"name": "Non-locking Type", "set_locked_on_confirmation": False}
+        )
+
+    def _create_po(self, order_type, price_unit=100.0):
+        return self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_type": order_type.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product_1.id,
+                            "product_qty": 1.0,
+                            "price_unit": price_unit,
+                        }
+                    ),
+                ],
+            }
+        )
+
+    def test_01_lock_on_confirmation_type_flag(self):
+        """AC2: tipo con flag ON + global OFF -> la orden queda bloqueada (state 'done')."""
+        po = self._create_po(self.type_lock)
+        po.button_confirm()
+        self.assertEqual(po.state, "done", "La OC de un tipo con 'Lock on Confirmation' debe quedar bloqueada")
+
+    def test_02_no_lock_without_flag(self):
+        """AC3: tipo con flag OFF + global OFF -> la orden queda editable (state 'purchase')."""
+        po = self._create_po(self.type_no_lock)
+        po.button_confirm()
+        self.assertEqual(po.state, "purchase", "Sin flag y sin lock global la OC debe quedar editable")
+
+    def test_03_global_lock_dominates(self):
+        """AC4: lock global ON -> bloquea siempre, sin importar el flag (apagado) del tipo."""
+        self.company.po_lock = "lock"
+        po = self._create_po(self.type_no_lock)
+        po.button_confirm()
+        self.assertEqual(po.state, "done", "Con el lock global prendido la OC debe quedar bloqueada igual")
+
+    def test_04_double_validation_respected(self):
+        """AC5: con doble validación el bloqueo se aplica al aprobar, no al confirmar."""
+        self.company.write(
+            {
+                "po_double_validation": "two_step",
+                "po_double_validation_amount": 100.0,
+            }
+        )
+        # Monto por encima del umbral confirmado por un usuario sin permiso de aprobar.
+        po = self._create_po(self.type_lock, price_unit=1000.0)
+        po.with_user(self.res_users_purchase_user).button_confirm()
+        self.assertEqual(po.state, "to approve", "Pendiente de aprobación no debe bloquearse todavía")
+        # Aprobación final (usuario manager) -> recién ahora bloquea.
+        po.button_approve()
+        self.assertEqual(po.state, "done", "Tras la aprobación final la OC del tipo con flag debe bloquearse")
+
+    def test_05_flag_hidden_setting_reflects_global(self):
+        """Análogo a Ventas: el check por tipo se oculta cuando el global manda.
+
+        La visibilidad la gobierna `lock_confirmed_po_setting`, que refleja el lock global de la
+        compañía del tipo. Con el global apagado el check queda visible; al prenderlo, se oculta.
+        """
+        self.type_lock.company_id = self.company
+        self.company.po_lock = "edit"
+        self.assertFalse(
+            self.type_lock.lock_confirmed_po_setting,
+            "Con el lock global apagado el check por tipo debe seguir visible",
+        )
+        self.company.po_lock = "lock"
+        self.type_lock.invalidate_recordset(["lock_confirmed_po_setting"])
+        self.assertTrue(
+            self.type_lock.lock_confirmed_po_setting,
+            "Con el lock global prendido el check por tipo debe ocultarse (como en Ventas)",
+        )

--- a/purchase_order_type_ux/views/purchase_order_type_views.xml
+++ b/purchase_order_type_ux/views/purchase_order_type_views.xml
@@ -19,6 +19,7 @@
                 <field name="report_partner_id"/>
                 <!-- <field name="partner_id" widget="many2many_tags"/> -->
                 <field name="picking_type_id"/>
+                <field name="set_locked_on_confirmation" invisible="lock_confirmed_po_setting"/>
             </xpath>
             <xpath expr="//form/sheet/group/group/field[@name='payment_term_id']" position="after">
                 <field name="journal_id" />

--- a/purchase_order_type_ux/views/res_config_settings_views.xml
+++ b/purchase_order_type_ux/views/res_config_settings_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.purchase.order.type.ux</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="purchase.res_config_settings_view_form_purchase" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//setting[@id='automatic_lock_confirmed_orders']/field[@name='lock_confirmed_po']"
+                position="after"
+            >
+                <div class="text-muted">
+                    When enabled, every confirmed order is locked, regardless of the per-type
+                    "Lock on Confirmation" flag. That flag (off by default on each Purchase Order Type)
+                    only takes effect when this setting is off; this global setting always prevails.
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## What

Adds a per-type **"Lock on Confirmation"** flag (`set_locked_on_confirmation`) on `purchase.order.type`. When enabled, purchase orders of that type are automatically locked once they are approved, so they can no longer be edited without an explicit unlock.

Until now the automatic lock could only be configured **globally per company** via the core **"Lock Confirmed Orders"** setting (`res.company.po_lock`), applied to every purchase order alike. This makes it configurable **per order type**.

## How

- New boolean `set_locked_on_confirmation` on `purchase.order.type` (default `False`), always visible/editable in the type form.
- Override of `purchase.order.button_approve()`: after `super()`, orders whose type has the flag and that just reached the approved state are moved to the locked state.
  - The hook is `button_approve` (not `button_confirm`) on purpose: in core the global lock is applied there too, and it only runs on final approval, so the per-type lock **respects the double-validation flow**.
  - In `purchase` the "locked" state is `state == 'done'` (there is no dedicated `locked` field like in `sale`), so we write that state, mirroring the core global-lock branch in `button_approve`.
- **Additive** to the global setting: when "Lock Confirmed Orders" is on, every confirmed order is locked regardless of the per-type flag — the global setting always prevails. A note next to the setting in Purchase Settings explains this.
- The flag defaults to `False`, so existing databases keep the current behavior on update.

## Test plan

`tests/test_purchase_order_type_ux.py` — all green on a fresh DB:

1. Type flag on + global off → PO locked on confirm (`state == 'done'`).
2. Type flag off + global off → PO stays editable (`state == 'purchase'`).
3. Global setting on → PO locked regardless of the (off) per-type flag.
4. Double validation → PO stays `to approve` (not locked) until final approval, then locks.

```
odoo-bin -d <db> -i purchase_order_type_ux --test-enable \
  --test-tags /purchase_order_type_ux --stop-after-init
# -> 0 failed, 0 error(s) of 4 tests
```

## Follow-up

- Forward-port to 19.0. The core lock mechanism must be re-checked there, since it may differ from 18.0 (this implementation is tied to `state == 'done'`).

Task: https://www.adhoc.inc/odoo/project.task/70022
