### PR TITLE
[IMP] purchase_ux: make order line list page size configurable

### DIFF
--- a/purchase_ux/__manifest__.py
+++ b/purchase_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase UX",
-    "version": "19.0.1.6.0",
+    "version": "19.0.1.7.0",
     "category": "Purchases",
     "sequence": 14,
     "summary": "Purchase order improvements: currency change, price updates, invoice controls and menu enhancements",

--- a/purchase_ux/i18n/purchase_ux.pot
+++ b/purchase_ux/i18n/purchase_ux.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-03 13:33+0000\n"
-"PO-Revision-Date: 2026-07-03 13:33+0000\n"
+"POT-Creation-Date: 2026-07-23 16:32+0000\n"
+"PO-Revision-Date: 2026-07-23 16:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -276,6 +276,19 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: purchase_ux
+#: model_terms:ir.ui.view,arch_db:purchase_ux.res_config_settings_view_form_purchase_ux
+msgid "Lines per page"
+msgstr ""
+
+#. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_res_config_settings__purchase_order_line_view_limit
+#: model_terms:ir.ui.view,arch_db:purchase_ux.res_config_settings_view_form_purchase_ux
+msgid ""
+"Lines shown per page on the order. Leave empty to keep the default; a lower "
+"value (e.g. 40) speeds up very long orders."
+msgstr ""
+
+#. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_product_product__main_seller_id
 #: model:ir.model.fields,field_description:purchase_ux.field_product_template__main_seller_id
 #: model_terms:ir.ui.view,arch_db:purchase_ux.product_template_search_view
@@ -382,6 +395,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:purchase_ux.field_account_move__purchase_order_ids
 #: model_terms:ir.ui.view,arch_db:purchase_ux.purchase_order_line_search
 msgid "Purchase Orders"
+msgstr ""
+
+#. module: purchase_ux
+#: model:ir.model.fields,field_description:purchase_ux.field_res_config_settings__purchase_order_line_view_limit
+msgid "Purchase order lines per page"
 msgstr ""
 
 #. module: purchase_ux

--- a/purchase_ux/models/purchase_order.py
+++ b/purchase_ux/models/purchase_order.py
@@ -136,3 +136,29 @@ class PurchaseOrder(models.Model):
         if self.internal_notes:
             result["internal_notes"] = self.internal_notes
         return result
+
+    def _order_line_view_limit(self):
+        """Configurable page size for the order_line list; 0 keeps the core default (ticket 121312)."""
+        param = self.env["ir.config_parameter"].sudo().get_param("purchase_ux.order_line_view_limit")
+        try:
+            # clamp to 0..200 (200 = Odoo's native max; higher only renders more rows)
+            return min(max(int(param or 0), 0), 200)
+        except ValueError:
+            return 0
+
+    @api.model
+    def _get_view_cache_key(self, view_id=None, view_type="form", **options):
+        key = super()._get_view_cache_key(view_id=view_id, view_type=view_type, **options)
+        # only the form arch depends on this param, so vary just the form cache key on change
+        if view_type == "form":
+            key += (self._order_line_view_limit(),)
+        return key
+
+    @api.model
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id=view_id, view_type=view_type, **options)
+        limit = self._order_line_view_limit()
+        if view_type == "form" and limit:
+            for node in arch.xpath("//field[@name='order_line']/list"):
+                node.set("limit", str(limit))
+        return arch, view

--- a/purchase_ux/models/res_config_settings.py
+++ b/purchase_ux/models/res_config_settings.py
@@ -2,7 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):
@@ -14,3 +14,18 @@ class ResConfigSettings(models.TransientModel):
         string="Skip Bill File Upload",
         help="When enabled, bills will be created directly without requiring file upload in purchase orders.",
     )
+    purchase_order_line_view_limit = fields.Integer(
+        string="Purchase order lines per page",
+        config_parameter="purchase_ux.order_line_view_limit",
+        help="Lines shown per page on the order. Leave empty to keep the default; "
+        "a lower value (e.g. 40) speeds up very long orders.",
+    )
+
+    @api.onchange("purchase_order_line_view_limit")
+    def _onchange_purchase_order_line_view_limit(self):
+        # 200 is Odoo's native max page size for the order line list; a higher value
+        # only renders more rows and slows the form, so it is capped there.
+        if self.purchase_order_line_view_limit < 0:
+            self.purchase_order_line_view_limit = 0
+        elif self.purchase_order_line_view_limit > 200:
+            self.purchase_order_line_view_limit = 200

--- a/purchase_ux/views/res_config_settings_views.xml
+++ b/purchase_ux/views/res_config_settings_views.xml
@@ -12,6 +12,12 @@
                     <field name="skip_upload"/>
                 </setting>
             </xpath>
+            <xpath expr="//block[@name='purchase_setting_container']" position="inside">
+                <setting id="purchase_order_line_view_limit" string="Lines per page"
+                    help="Lines shown per page on the order. Leave empty to keep the default; a lower value (e.g. 40) speeds up very long orders.">
+                    <field name="purchase_order_line_view_limit"/>
+                </setting>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
## What
Make the order line list page size configurable on the purchase order form.

## Why
Odoo core v19 hardcodes `limit="200"` on the `order_line` `<list>` of the purchase order form (v18 used the default 40 with pagination). On purchase orders with many lines this loads all 200 at once and slows the browser render. This adds an admin setting to restore pagination; default-off (empty/0 keeps the core behavior).

## How
- New setting **Lines per page** under *Settings → Purchase* backed by `ir.config_parameter` `purchase_ux.order_line_view_limit`.
- `purchase.order._get_view` sets `limit` on the `order_line` list when the parameter is > 0; `_get_view_cache_key` folds the value into the form view cache key so changing the setting invalidates the cached arch.
- Empty / 0 / non-numeric / negative → no change, core default (200) is kept.

## Test plan
1. Upgrade `purchase_ux`.
2. *Settings → Purchase → Lines per page* = 40; open a PO with > 200 lines → lines paginate at 40.
3. Clear the setting → 200 without pagination (core default).
4. Set a non-numeric or negative value on the System Parameter → views still load, value is treated as 0.

Companion PR in `sale_ux` for the same ticket (independent, mirrors the same change on sale orders).
