### PR TITLE
[FIX] purchase_ux: use a per document type criterion in purchase matching

### DIFF
--- a/purchase_ux/models/account_move.py
+++ b/purchase_ux/models/account_move.py
@@ -93,12 +93,14 @@ class AccountMove(models.Model):
             ctx["purchase_matching_from_button"] = True
             ctx["default_account_move_id"] = self.id
             res["context"] = ctx
-            # Show POLs with a pending amount to invoice, using qty_to_invoice so that
-            # returns are handled: on a bill (in_invoice) we want lines still to bill
-            # (qty_to_invoice > 0), on a credit note (in_refund) we want lines with a
-            # pending refund left by a return (qty_to_invoice < 0). The previous check
-            # (product_qty > qty_invoiced) ignored returns, since product_qty does not
-            # drop with a return, and hid those lines from the matcher.
+            # Show POLs with something pending, with a different criterion per document type:
+            # * on a bill (in_invoice): ordered qty not billed yet (product_qty > qty_invoiced),
+            #   received or not. qty_to_invoice cannot be used here because on products
+            #   controlled on received quantities it is qty_received - qty_invoiced, so a
+            #   confirmed PO with no receipt yet gives 0 and the line would be hidden.
+            # * on a credit note (in_refund): lines left with a pending refund by a return,
+            #   ie. billed more than received (qty_to_invoice < 0). product_qty cannot be used
+            #   here because it does not drop with a return, so a fully billed line gives 0.
             all_pols = self.env["purchase.order.line"].search(
                 [
                     ("partner_id", "in", (self.partner_id | self.partner_id.commercial_partner_id).ids),
@@ -113,8 +115,9 @@ class AccountMove(models.Model):
             def _pending(pol):
                 if pol.id in already_matched:
                     return False
-                sign = float_compare(pol.qty_to_invoice, 0.0, precision_digits=uom_precision)
-                return sign < 0 if is_refund else sign > 0
+                if is_refund:
+                    return float_compare(pol.qty_to_invoice, 0.0, precision_digits=uom_precision) < 0
+                return float_compare(pol.product_qty, pol.qty_invoiced, precision_digits=uom_precision) > 0
 
             pending_pol_ids = all_pols.filtered(_pending).ids
             domain = list(res.get("domain") or [])


### PR DESCRIPTION
Fixes a regression introduced by #351 in the "Match purchase lines" matcher.

#351 switched the filter of `action_purchase_matching` to `qty_to_invoice` for
both document types. That fixed credit notes, but broke bills: on products
controlled on **received** quantities `qty_to_invoice` is
`qty_received - qty_invoiced`, so a confirmed purchase order with no receipt yet
gives `0` and **no purchase order line at all** was offered when matching a
vendor bill.

The two cases need opposite criteria, so the filter now branches per
`move_type`:

* `in_invoice` → `product_qty > qty_invoiced`: ordered quantity not billed yet,
  received or not (restores the pre-#351 behaviour).
* `in_refund` → `qty_to_invoice < 0`: the pending credit left by a return on a
  line that is already fully billed (keeps the fix from #351).

`float_compare` with the UoM precision and the exclusion of lines already
matched in the same document are unchanged.
