### PR TITLE
[FIX] purchase_stock_ux: do not flag zero-qty and note lines as pending receipt

### DIFF
--- a/purchase_stock_ux/models/purchase_order_line.py
+++ b/purchase_stock_ux/models/purchase_order_line.py
@@ -33,7 +33,7 @@ class PurchaseOrderLine(models.Model):
     qty_on_voucher = fields.Float(
         compute="_compute_qty_on_voucher",
         string="On Voucher",
-        digits="Product Unit of Measure",
+        digits="Product Unit",
     )
 
     qty_returned = fields.Float(
@@ -138,22 +138,31 @@ class PurchaseOrderLine(models.Model):
                     vouchers += picking.voucher_ids.mapped("display_name")
             rec.vouchers = ", ".join(vouchers)
 
-    @api.depends("order_id.state", "qty_received", "qty_returned", "product_qty", "order_id.force_delivered_status")
+    @api.depends(
+        "display_type",
+        "order_id.state",
+        "qty_received",
+        "qty_returned",
+        "product_qty",
+        "order_id.force_delivered_status",
+    )
     def _compute_receipt_status(self):
-        precision = self.env["decimal.precision"].precision_get("Product Unit of Measure")
+        precision = self.env["decimal.precision"].precision_get("Product Unit")
         for line in self:
-            if line.state not in ("purchase", "done"):
+            if line.display_type or line.state not in ("purchase", "done"):
                 line.receipt_status = False
                 continue
             if line.order_id.force_delivered_status:
                 line.receipt_status = line.order_id.force_delivered_status
                 continue
 
+            # 'full' antes que 'pending': una línea sin nada pedido (product_qty 0, ej. anulada
+            # bajando la cantidad) no tiene nada por recibir
             qty_total = line.qty_received + line.qty_returned
-            if float_is_zero(qty_total, precision_digits=precision):
-                line.receipt_status = "pending"
-            elif float_compare(qty_total, line.product_qty, precision_digits=precision) >= 0:
+            if float_compare(qty_total, line.product_qty, precision_digits=precision) >= 0:
                 line.receipt_status = "full"
+            elif float_is_zero(qty_total, precision_digits=precision):
+                line.receipt_status = "pending"
             else:
                 line.receipt_status = "partial"
 
@@ -243,7 +252,7 @@ class PurchaseOrderLine(models.Model):
 
     @api.depends("order_id.state", "qty_invoiced", "product_qty", "qty_to_invoice", "order_id.force_invoiced_status")
     def _compute_invoice_status(self):
-        precision = self.env["decimal.precision"].precision_get("Product Unit of Measure")
+        precision = self.env["decimal.precision"].precision_get("Product Unit")
         super()._compute_invoice_status()
         for line in self:
             if not float_is_zero(line.qty_to_invoice, precision_digits=precision):

--- a/purchase_stock_ux/tests/test_purchase_order.py
+++ b/purchase_stock_ux/tests/test_purchase_order.py
@@ -309,3 +309,64 @@ class TestPurchaseOrder(PurchaseTestCommon):
         # El movimiento entregado debe quedar intacto.
         self.assertEqual(done_move.state, "done")
         self.assertFalse(draft_po.order_line)
+
+    def _confirmed_po_with_note(self):
+        """OC confirmada con una línea de producto y una nota."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_qty": 10,
+                            "price_unit": 50,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "display_type": "line_note",
+                            "name": "Handle with care",
+                            "product_id": False,
+                            "product_qty": 0.0,
+                            "product_uom_id": False,
+                            "price_unit": 0.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        po.button_confirm()
+        return po
+
+    def test_receipt_status_note_line_has_no_status(self):
+        """Las notas no tienen nada por recibir: receipt_status vacío, no 'pending'."""
+        po = self._confirmed_po_with_note()
+        note = po.order_line.filtered(lambda line: line.display_type)
+
+        self.assertFalse(note.receipt_status, "Una nota no debe quedar como pendiente de recibir")
+
+    def test_receipt_status_zero_qty_line_is_not_pending(self):
+        """Línea anulada bajando la cantidad a 0: no queda nada por recibir."""
+        po = self._confirmed_po_with_note()
+        line = po.order_line.filtered(lambda line: not line.display_type)
+        self.assertEqual(line.receipt_status, "pending", "Sanity check: sin recibir arranca pendiente")
+
+        line.product_qty = 0
+
+        self.assertEqual(line.receipt_status, "full", "Sin cantidad pedida no queda nada por recibir")
+
+    def test_receipt_status_partial_and_full(self):
+        """Recepción parcial y total siguen mapeando a 'partial' y 'full'."""
+        po = self._confirmed_po_with_note()
+        line = po.order_line.filtered(lambda line: not line.display_type)
+
+        picking = po.picking_ids
+        picking.move_ids.quantity = 4
+        picking.with_context(skip_backorder=True).button_validate()
+        self.assertEqual(line.receipt_status, "partial")
+
+        backorder = po.picking_ids - picking
+        backorder.move_ids.quantity = 6
+        backorder.with_context(skip_backorder=True).button_validate()
+        self.assertEqual(line.receipt_status, "full")

--- a/purchase_stock_ux/views/purchase_line_views.xml
+++ b/purchase_stock_ux/views/purchase_line_views.xml
@@ -23,7 +23,9 @@
         <field name="arch" type="xml">
             <filter position="before">
                 <field name="vouchers" string="Vouchers" filter_domain="[('move_ids.picking_id.voucher_ids', 'like', self)]" context="{'voucher': self}"/>
+                <filter name="to_receive" string="To Receive" domain="[('receipt_status','in', ('pending', 'partial'))]"/>
                 <filter name="not_received" string="Not Received" domain="[('receipt_status','=', 'pending')]"/>
+                <filter name="partial" string="Partially Received" domain="[('receipt_status','=', 'partial')]"/>
                 <filter name="received" string="Received" domain="[('receipt_status','=', 'full')]"/>
                 <separator/>
             </filter>


### PR DESCRIPTION
## Problem

`purchase.order.line._compute_receipt_status` checks `float_is_zero(qty_total)` **before** comparing against `product_qty`, so any line with nothing ordered is stuck on `pending` forever:

- **note / section lines** — the core `CHECK` constraint forces `product_qty = 0` on them, so they always land in the zero branch;
- **lines voided by setting the quantity to 0**, a common way to drop a line from a confirmed PO.

In 18.0 the same lines computed as `received` (`float_compare(0, 0) >= 0`), so this is a regression introduced with the `delivery_status` -> `receipt_status` rewrite. On a migrated database, ~45% of the lines returned by the "Not Received" filter were these false positives.

The line search view is also missing a filter for `partial`: with only `Not Received` (= `pending`) and `Received` (= `full`), partially received lines are unreachable — and there is no equivalent of the 18.0 "To Receive" filter, which covered `pending` + `partial`.

## Fix

- Evaluate `full` before `pending`, and skip `display_type` lines (they get no receipt status at all). `display_type` added to `@api.depends`.
- Add the `To Receive` (`pending` + `partial`) and `Partially Received` filters to the order line search view.
- Unrelated but adjacent: `precision_get("Product Unit of Measure")` no longer matches in 19.0 — the record is now named `Product Unit`, so the lookup silently fell back to the default of 2 digits. Fixed in `_compute_receipt_status`, `_compute_invoice_status` and the `digits` of `qty_on_voucher`.

## Test plan

Three regression tests in `purchase_stock_ux/tests/test_purchase_order.py`:

- `test_receipt_status_note_line_has_no_status` — a note line gets no receipt status.
- `test_receipt_status_zero_qty_line_is_not_pending` — a confirmed line whose quantity drops to 0 becomes `full`, not `pending`.
- `test_receipt_status_partial_and_full` — partial and full receipts still map correctly (no regression).

```
0 failed, 0 error(s) of 10 tests
```

Reverting only the compute makes the first two fail (`2 failed of 10`), so they discriminate.

Internal ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/124742