### PR TITLE
[FIX] purchase_ux: complete the pending criterion in purchase matching

### DIFF
--- a/purchase_ux/models/account_move.py
+++ b/purchase_ux/models/account_move.py
@@ -95,12 +95,14 @@ class AccountMove(models.Model):
             res["context"] = ctx
             # Show POLs with something pending, with a different criterion per document type:
             # * on a bill (in_invoice): ordered qty not billed yet (product_qty > qty_invoiced),
-            #   received or not. qty_to_invoice cannot be used here because on products
-            #   controlled on received quantities it is qty_received - qty_invoiced, so a
+            #   received or not, or qty pending to bill (qty_to_invoice > 0) for an over receipt,
+            #   fully ordered but not fully billed. qty_to_invoice cannot be used alone because on
+            #   products controlled on received quantities it is qty_received - qty_invoiced, so a
             #   confirmed PO with no receipt yet gives 0 and the line would be hidden.
             # * on a credit note (in_refund): lines left with a pending refund by a return,
             #   ie. billed more than received (qty_to_invoice < 0). product_qty cannot be used
             #   here because it does not drop with a return, so a fully billed line gives 0.
+            # POs with a forced invoice status are excluded: nothing left to bill on them.
             all_pols = self.env["purchase.order.line"].search(
                 [
                     ("partner_id", "in", (self.partner_id | self.partner_id.commercial_partner_id).ids),
@@ -113,11 +115,14 @@ class AccountMove(models.Model):
             uom_precision = self.env["decimal.precision"].precision_get("Product Unit of Measure")
 
             def _pending(pol):
-                if pol.id in already_matched:
+                if pol.id in already_matched or pol.order_id.force_invoiced_status:
                     return False
                 if is_refund:
                     return float_compare(pol.qty_to_invoice, 0.0, precision_digits=uom_precision) < 0
-                return float_compare(pol.product_qty, pol.qty_invoiced, precision_digits=uom_precision) > 0
+                return (
+                    float_compare(pol.product_qty, pol.qty_invoiced, precision_digits=uom_precision) > 0
+                    or float_compare(pol.qty_to_invoice, 0.0, precision_digits=uom_precision) > 0
+                )
 
             pending_pol_ids = all_pols.filtered(_pending).ids
             domain = list(res.get("domain") or [])

--- a/purchase_ux/models/purchase_order.py
+++ b/purchase_ux/models/purchase_order.py
@@ -46,12 +46,10 @@ class PurchaseOrder(models.Model):
             raise UserError(
                 _('Only users with "%s / %s" can Set Invoiced manually') % (group.category_id.name, group.name)
             )
-        # In purchases the invoice status is not calculated from the lines,
-        # so we step on it in the PO. Do not step on the qty_invoiced because
-        # it seems more neat to restore what happened
-
-        self.write({"invoice_status": "invoiced"})
-        self.order_line.write({"qty_to_invoice": 0.0})
+        # force_invoiced_status is the only value that survives a recompute: both
+        # invoice_status and qty_to_invoice are stored computed fields, so stamping
+        # them was undone by the next recompute of the order or its lines.
+        self.write({"force_invoiced_status": "invoiced"})
         self.message_post(body=_("Manually setted as invoiced"))
 
     def write(self, vals):

--- a/purchase_ux/tests/__init__.py
+++ b/purchase_ux/tests/__init__.py
@@ -3,4 +3,5 @@
 # directory
 ##############################################################################
 
+from . import test_purchase_matching
 from . import test_purchase_order

--- a/purchase_ux/tests/test_purchase_matching.py
+++ b/purchase_ux/tests/test_purchase_matching.py
@@ -1,0 +1,108 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseMatching(AccountTestInvoicingCommon):
+    """Lines offered by the purchase matching action, ordered/received/billed."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # forcing the invoice status of a PO is restricted to settings managers
+        cls.env.user.groups_id |= cls.env.ref("base.group_system")
+        cls.vendor = cls.env["res.partner"].create({"name": "Test Vendor Matching"})
+        # a service controlled on received quantities lets us set qty_received by hand
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Service On Received",
+                "type": "service",
+                "purchase_method": "receive",
+            }
+        )
+
+    def _line(self, ordered, received=0.0, forced=False):
+        purchase = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create({"product_id": self.product.id, "product_qty": ordered, "price_unit": 100.0})
+                ],
+            }
+        )
+        purchase.button_confirm()
+        purchase.order_line.qty_received = received
+        purchase.force_invoiced_status = forced
+        return purchase.order_line
+
+    def _bill(self, line, quantity, move_type="in_invoice"):
+        self.env["account.move"].create(
+            {
+                "move_type": move_type,
+                "partner_id": self.vendor.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": quantity,
+                            "price_unit": 100.0,
+                            "purchase_line_id": line.id,
+                            "tax_ids": False,
+                        }
+                    )
+                ],
+            }
+        ).action_post()
+
+    def _offered(self, move_type="in_invoice"):
+        move = self.env["account.move"].create({"move_type": move_type, "partner_id": self.vendor.id})
+        action = move.action_purchase_matching()
+        self.env.flush_all()  # the matching model is a SQL view read from the database
+        return self.env["purchase.bill.line.match"].search(action["domain"]).pol_id
+
+    def test_bill_not_received(self):
+        self.assertIn(self._line(100), self._offered())
+
+    def test_bill_partially_received(self):
+        self.assertIn(self._line(100, received=60), self._offered())
+
+    def test_bill_over_receipt(self):
+        line = self._line(40, received=41)
+        self._bill(line, 40)
+        self.assertIn(line, self._offered())
+
+    def test_bill_fully_billed(self):
+        line = self._line(100, received=100)
+        self._bill(line, 100)
+        self.assertNotIn(line, self._offered())
+
+    def test_bill_forced_invoiced_status(self):
+        self.assertNotIn(self._line(100, forced="invoiced"), self._offered())
+
+    def test_bill_set_invoiced_button(self):
+        """The Set Invoiced button closes the order for billing, and it sticks."""
+        line = self._line(100, received=60)
+        line.order_id.button_set_invoiced()
+        self.assertEqual(line.order_id.force_invoiced_status, "invoiced")
+        self.assertEqual(line.order_id.invoice_status, "invoiced")
+        self.assertNotIn(line, self._offered())
+        line.qty_received = 80  # a later recompute must not bring it back
+        self.assertEqual(line.order_id.invoice_status, "invoiced")
+        self.assertNotIn(line, self._offered())
+
+    def test_refund_pending_from_return(self):
+        line = self._line(600, received=500)
+        self._bill(line, 600)
+        self.assertIn(line, self._offered(move_type="in_refund"))
+
+    def test_refund_already_credited(self):
+        line = self._line(600, received=500)
+        self._bill(line, 600)
+        self._bill(line, 100, move_type="in_refund")
+        self.assertNotIn(line, self._offered(move_type="in_refund"))


### PR DESCRIPTION
Completes the criterion of the lines offered by the *Match purchase lines* button, on top of #351 and #353.

### 1. Over receipt was hidden on bills

The bill criterion is `product_qty > qty_invoiced`. When the vendor delivers more than ordered, the line ends up *ordered = billed* but *received > billed*, so there is a legitimate quantity left to bill and the line disappeared from the matcher (ordered 40, received 41, billed 40 → 1 pending).

Fixed by adding `qty_to_invoice > 0` as a second term, the same criterion the native view uses (`purchase/models/purchase_bill_line_match.py`, `_select_po_line()`). The first term is still needed: on products controlled on received quantities `qty_to_invoice` is `qty_received - qty_invoiced`, so a confirmed purchase order with no receipt yet gives 0 — that is the regression #353 fixed. The `in_refund` criterion is untouched.

### 2. The filter ignored `force_invoiced_status`

Neither this filter nor the native view read `force_invoiced_status` / `invoice_status`, so an order manually set as *No Bill to Receive* / *Nothing to Bill* kept offering its lines: with ordered 10 and billed 0 the first term is still True, and `button_set_invoiced()` only zeroes `qty_to_invoice`. Setting the status is the documented way to close an order for billing, so those lines are now excluded, on bills and on credit notes alike.

### Test plan

`purchase_ux/tests/test_purchase_matching.py`, 7 cases. Bill criterion: confirmed order with no receipt (offered), partial receipt not billed (offered), over receipt 40/41/40 (offered — point 1), fully received and billed (not offered), forced invoice status (not offered — point 2). Credit note criterion: pending refund from a return 600/500/600 (offered), return already credited 600/500/500 (not offered).

Verified locally on 18.0: 0 failed, 0 errors of 10 tests. Reverting only `account_move.py` fails `test_bill_over_receipt` and `test_bill_forced_invoiced_status`, and leaves the other five green.

### Known limitation, out of scope

A line returned and already credited (ordered 150, net billed 0) still shows as 150 pending on bills. It happens with the previous criterion and with the native one too; whether it is tolerated is a product decision.

https://www.adhoc.inc/odoo/project.task/72358


### 3. Orders closed with the *Set Invoiced* button

`button_set_invoiced()` stamped `invoice_status` on the order and zeroed `qty_to_invoice` on its lines. Both are stored computed fields, so the next recompute undid it: right after pressing the button the order reads *Nothing to Bill* instead of *No Bill to Receive*, and any later recompute — writing on a line is enough — brings it back to *Waiting Bills* with the full quantity pending. Neither the matcher nor the line status ever treated those orders as closed, since both read `force_invoiced_status`, which the button never set. It now writes that field, which is durable and is what the rest of the module reads. This is the path a mass cleanup goes through, so without it the exclusion of point 2 never applies to it.

`test_bill_set_invoiced_button` covers it: after the button the order keeps `force_invoiced_status` and *No Bill to Receive*, the matcher does not offer its lines, and a later change of the received quantity does not bring it back. The behaviour was verified on 19.0 (same code); on 18.0 it rides on CI. The line level status of those orders only becomes correct together with #361.
