### PR TITLE
[FIX] purchase_ux: complete the pending criterion in purchase matching

### DIFF
--- a/purchase_ux/models/account_move.py
+++ b/purchase_ux/models/account_move.py
@@ -103,9 +103,11 @@ class AccountMove(models.Model):
             ]
             # Show POLs with something pending, with a different criterion per document type:
             # * on a bill (in_invoice): ordered qty not billed yet (product_qty > qty_invoiced),
-            #   received or not. qty_to_invoice cannot be used here because on products
-            #   controlled on received quantities it is qty_received - qty_invoiced, so a
-            #   confirmed PO with no receipt yet gives 0 and the line would be hidden.
+            #   received or not, or qty still pending to bill (qty_to_invoice > 0), the only term
+            #   that catches an over receipt, fully ordered but not fully billed. qty_to_invoice
+            #   alone cannot be used because on products controlled on received quantities it is
+            #   qty_received - qty_invoiced, so a confirmed PO with no receipt yet gives 0 and the
+            #   line would be hidden.
             # * on a credit note (in_refund): lines left with a pending refund by a return,
             #   ie. billed more than received (qty_to_invoice < 0). product_qty cannot be used
             #   here because it does not drop with a return, so a fully billed line gives 0.
@@ -125,7 +127,10 @@ class AccountMove(models.Model):
                     return False
                 if is_refund:
                     return float_compare(pol.qty_to_invoice, 0.0, precision_digits=uom_precision) < 0
-                return float_compare(pol.product_qty, pol.qty_invoiced, precision_digits=uom_precision) > 0
+                return (
+                    float_compare(pol.product_qty, pol.qty_invoiced, precision_digits=uom_precision) > 0
+                    or float_compare(pol.qty_to_invoice, 0.0, precision_digits=uom_precision) > 0
+                )
 
             pending_pol_ids = all_pols.filtered(_pending).ids
             domain = list(res.get("domain") or [])

--- a/purchase_ux/models/purchase_bill_line_match.py
+++ b/purchase_ux/models/purchase_bill_line_match.py
@@ -39,12 +39,13 @@ class PurchaseBillLineMatch(models.Model):
 
     @property
     def _table_query(self):
+        # any forced invoice status closes the order for billing, also 'no' (nothing to bill)
         return SQL(
             """
             SELECT base.* FROM (%s) AS base
             WHERE base.purchase_order_id IS NULL
                OR base.purchase_order_id NOT IN (
-                   SELECT id FROM purchase_order WHERE force_invoiced_status = 'invoiced'
+                   SELECT id FROM purchase_order WHERE force_invoiced_status IS NOT NULL
                )
             """,
             super()._table_query,

--- a/purchase_ux/models/purchase_order.py
+++ b/purchase_ux/models/purchase_order.py
@@ -50,12 +50,10 @@ class PurchaseOrder(models.Model):
                 )
             else:
                 raise UserError(_('Only users with "%s" can Set Invoiced manually') % (group.name))
-        # In purchases the invoice status is not calculated from the lines,
-        # so we step on it in the PO. Do not step on the qty_invoiced because
-        # it seems more neat to restore what happened
-
-        self.write({"invoice_status": "invoiced"})
-        self.order_line.write({"qty_to_invoice": 0.0})
+        # force_invoiced_status is the only value that survives a recompute: both
+        # invoice_status and qty_to_invoice are stored computed fields, so stamping
+        # them was undone by the next recompute of the order or its lines.
+        self.write({"force_invoiced_status": "invoiced"})
         self.message_post(body=_("Manually setted as invoiced"))
 
     def write(self, vals):

--- a/purchase_ux/tests/__init__.py
+++ b/purchase_ux/tests/__init__.py
@@ -3,4 +3,5 @@
 # directory
 ##############################################################################
 
+from . import test_purchase_matching
 from . import test_purchase_order

--- a/purchase_ux/tests/test_purchase_matching.py
+++ b/purchase_ux/tests/test_purchase_matching.py
@@ -1,0 +1,109 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPurchaseMatching(AccountTestInvoicingCommon):
+    """Lines offered by the purchase matching action, ordered/received/billed."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # forcing the invoice status of a PO is restricted to settings managers
+        cls.env.user.group_ids |= cls.env.ref("base.group_system")
+        cls.vendor = cls.env["res.partner"].create({"name": "Test Vendor Matching"})
+        # a service controlled on received quantities lets us set qty_received by hand
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Service On Received",
+                "type": "service",
+                "purchase_method": "receive",
+            }
+        )
+
+    def _line(self, ordered, received=0.0, forced=False):
+        purchase = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "order_line": [
+                    Command.create({"product_id": self.product.id, "product_qty": ordered, "price_unit": 100.0})
+                ],
+            }
+        )
+        purchase.button_confirm()
+        purchase.order_line.qty_received = received
+        purchase.force_invoiced_status = forced
+        return purchase.order_line
+
+    def _bill(self, line, quantity, move_type="in_invoice"):
+        self.env["account.move"].create(
+            {
+                "move_type": move_type,
+                "partner_id": self.vendor.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "quantity": quantity,
+                            "price_unit": 100.0,
+                            "purchase_line_id": line.id,
+                            "tax_ids": False,
+                        }
+                    )
+                ],
+            }
+        ).action_post()
+
+    def _offered(self, move_type="in_invoice"):
+        move = self.env["account.move"].create({"move_type": move_type, "partner_id": self.vendor.id})
+        action = move.action_purchase_matching()
+        self.env.flush_all()  # the matching model is a SQL view read from the database
+        return self.env["purchase.bill.line.match"].search(action["domain"]).pol_id
+
+    def test_bill_not_received(self):
+        self.assertIn(self._line(100), self._offered())
+
+    def test_bill_partially_received(self):
+        self.assertIn(self._line(100, received=60), self._offered())
+
+    def test_bill_over_receipt(self):
+        line = self._line(40, received=41)
+        self._bill(line, 40)
+        self.assertIn(line, self._offered())
+
+    def test_bill_fully_billed(self):
+        line = self._line(100, received=100)
+        self._bill(line, 100)
+        self.assertNotIn(line, self._offered())
+
+    def test_bill_forced_invoiced_status(self):
+        for forced in ("invoiced", "no"):
+            self.assertNotIn(self._line(100, forced=forced), self._offered())
+
+    def test_bill_set_invoiced_button(self):
+        """The Set Invoiced button closes the order for billing, and it sticks."""
+        line = self._line(100, received=60)
+        line.order_id.button_set_invoiced()
+        self.assertEqual(line.order_id.force_invoiced_status, "invoiced")
+        self.assertEqual(line.order_id.invoice_status, "invoiced")
+        self.assertNotIn(line, self._offered())
+        line.qty_received = 80  # a later recompute must not bring it back
+        self.assertEqual(line.order_id.invoice_status, "invoiced")
+        self.assertNotIn(line, self._offered())
+
+    def test_refund_pending_from_return(self):
+        line = self._line(600, received=500)
+        self._bill(line, 600)
+        self.assertIn(line, self._offered(move_type="in_refund"))
+
+    def test_refund_already_credited(self):
+        line = self._line(600, received=500)
+        self._bill(line, 600)
+        self._bill(line, 100, move_type="in_refund")
+        self.assertNotIn(line, self._offered(move_type="in_refund"))

--- a/purchase_ux/views/purchase_order_views.xml
+++ b/purchase_ux/views/purchase_order_views.xml
@@ -19,7 +19,7 @@
             </field>
 
             <button name="button_confirm" position="after">
-                <button name="button_set_invoiced" type="object" string="Set Invoiced" invisible="state != 'done' or invoice_status != 'to invoice'" confirm="This order will be setted as invoiced. This operation can't be undone. Are you sure do you want to continue?" groups="base.group_no_one"/>
+                <button name="button_set_invoiced" type="object" string="Set Invoiced" invisible="not locked or invoice_status != 'to invoice'" confirm="This order will be setted as invoiced. This operation can't be undone. Are you sure do you want to continue?" groups="base.group_no_one"/>
             </button>
 
             <field name="invoice_status" position="before">


### PR DESCRIPTION
Port of #359 to 19.0. Rebased on 19.0 after #354 was merged, which brought the per document type criterion this branch was missing, so that part is no longer in the diff — only its tests are kept, see 1. What is left are three defects that 19.0 still has.

### 1. Credit notes (#351, #353, #354) — already merged, tests only

`product_qty` does not drop with a return, so a line that is already fully billed but has a pending credit (`qty_to_invoice < 0`) was hidden from the matcher of a credit note. Fixed on this branch by #354 (`bed8052`); this PR only adds the two regression tests it never got.

### 2. Over receipt on bills (#359)

When the vendor delivers more than ordered, the line ends up *ordered = billed* but *received > billed*, so there is a legitimate quantity left to bill and the line disappeared from the matcher (ordered 40, received 41, billed 40 → 1 pending). Fixed by adding `qty_to_invoice > 0` as a second term to the `in_invoice` criterion, the same one the native view uses (`purchase/models/purchase_bill_line_match.py`, `_select_po_line()`). The first term is still needed: on products controlled on received quantities `qty_to_invoice` is `qty_received - qty_invoiced`, so a confirmed purchase order with no receipt yet gives 0 and every line would be hidden — that is exactly the regression #354 fixed, so both terms have to stay.

### 3. Orders set as *Nothing to Bill*

The view already excludes orders forced as *No Bill to Receive*, but not the other value of `force_invoiced_status`, even though both mean the order is closed for billing. The exclusion now covers any forced status. Unlike #359, this branch does not need it in the action: the filter lives in the view, which is the better place, so the action only carries the quantity criterion.

### 4. Orders closed with the *Set Invoiced* button

`button_set_invoiced()` stamped `invoice_status` on the order and zeroed `qty_to_invoice` on its lines. Both are stored computed fields, so the next recompute undid it. Verified on 19.0: right after pressing the button the order reads *Nothing to Bill* instead of *No Bill to Receive*, and any later recompute — writing on a line is enough — brings it back to *Waiting Bills* with the full quantity pending. Neither the matcher nor the line status ever treated those orders as closed, since both read `force_invoiced_status`, which the button never set. It now writes that field, which is durable and is what the rest of the module reads.

Its `invisible` domain never matched on this branch either: purchase orders no longer have the `done` state on 19.0 (it is the `locked` boolean now), so the button was unreachable in the form. It is gated on `locked` now.

### Test plan

`purchase_ux/tests/test_purchase_matching.py`, 8 cases. Bill criterion: confirmed order with no receipt (offered), partial receipt not billed (offered), over receipt 40/41/40 (offered), fully received and billed (not offered), forced invoice status, both values (not offered). *Set Invoiced* button: order closed, matcher does not offer its lines, and a later change of the received quantity does not bring it back. Credit note criterion: pending refund from a return 600/500/600 (offered), return already credited 600/500/500 (not offered).

Verified locally on 19.0 over the rebased branch: 0 failed, 0 errors of 12 tests. Reverting `purchase_ux/models/` and `purchase_ux/views/` to 19.0 fails exactly the three that cover what is left in the diff — `test_bill_over_receipt`, `test_bill_set_invoiced_button` and the `'no'` subtest of `test_bill_forced_invoiced_status` — and leaves the rest green, the two credit note ones included, since that criterion is already in the branch.

### Known limitation, out of scope

A line returned and already credited (ordered 150, net billed 0) still shows as 150 pending on bills. It happens with the previous criterion and with the native one too; whether it is tolerated is a product decision.

Note for the merge: this touches a view, so it needs `bump`, not `nobump`. The line level status of those orders only becomes correct together with #362.

https://www.adhoc.inc/odoo/project.task/72358
