### PR TITLE
[IMP] purchase_ux: add pivot view to purchase lines menu

### DIFF
--- a/purchase_ux/README.rst
+++ b/purchase_ux/README.rst
@@ -35,6 +35,7 @@ Purchase Order Lines
 
 * Use product standard price when supplier price is not available (seller price = 0.0)
 * Enhanced invoice quantity management and controls
+* Add pivot view to the purchase lines menu, to analyse lines without a predefined report
 
 
 Installation

--- a/purchase_ux/__manifest__.py
+++ b/purchase_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase UX",
-    "version": "19.0.1.7.0",
+    "version": "19.0.1.8.0",
     "category": "Purchases",
     "sequence": 14,
     "summary": "Purchase order improvements: currency change, price updates, invoice controls and menu enhancements",

--- a/purchase_ux/tests/test_purchase_order.py
+++ b/purchase_ux/tests/test_purchase_order.py
@@ -77,3 +77,10 @@ class TestPurchaseOrder(common.ProductCommon):
             "<p>Test internal notes</p>",
             "Internal notes should be transferred to the invoice.",
         )
+
+    def test_purchase_line_action_has_pivot(self):
+        """The purchase lines menu offers a pivot view, as the sale lines one does."""
+        action = self.env.ref("purchase_ux.action_purchase_line_tree")
+        self.assertIn("pivot", action.view_mode)
+        views = self.env["purchase.order.line"].get_views(action.views)["views"]
+        self.assertIn("pivot", views)

--- a/purchase_ux/views/purchase_line_views.xml
+++ b/purchase_ux/views/purchase_line_views.xml
@@ -5,6 +5,7 @@
         <field name="context">{'search_default_approved': 1}</field>
         <!-- <field name="domain">[('product_id.product_tmpl_id','in',active_ids)]</field> -->
         <field name="name">Purchase Lines</field>
+        <field name="view_mode">list,form,pivot</field>
         <field name="res_model">purchase.order.line</field>
         <field name="view_id" ref="purchase.purchase_order_line_tree"/>
     </record>


### PR DESCRIPTION
### Context

The purchase lines menu (`purchase_ux.action_purchase_line_tree`) only declared list and form views, so the view switcher had no pivot button. The equivalent sale lines menu (`sale_ux.action_sale_order_line_usability_tree`) already offers an empty pivot, letting each user build the analysis they need over the lines (by vendor, product, date, ...) without a predefined report.

### Change

* `purchase_ux`: add `pivot` to the `view_mode` of the purchase lines action, mirroring the sale side. No pivot view is defined — it opens empty, with the `Count` measure only.
* The action keeps its current `search_default_approved` context (confirmed purchase orders), same as sales does with confirmed ones.
* Graph view is intentionally left out: it is not enabled on the sale side either.

### Test plan

* New test `test_purchase_line_action_has_pivot` in `purchase_ux/tests/test_purchase_order.py`: asserts the action declares the pivot mode and that `purchase.order.line` actually resolves a pivot view for it.
* Verified locally on a clean 19.0 database: `0 failed, 0 error(s)`. Reverting the XML change makes the new test fail with `'pivot' not found in 'list,form'`.
* Manually: *Purchases → Purchase Lines* now shows the pivot button next to the list one.

Task: https://www.adhoc.inc/odoo/knowledge/12857/all-tasks/69797
