### PR TITLE
[FIX] purchase_ux: always offer purchase order optional column

### DIFF
--- a/purchase_ux/views/account_move_views.xml
+++ b/purchase_ux/views/account_move_views.xml
@@ -10,6 +10,14 @@
             </field>
 
 
+            <!-- La columna de OC depende de parent.move_type y, cuando la condición no se
+                 cumple, la opción desaparece del menú de columnas opcionales en lugar de
+                 quedar destildada, así que el usuario no tiene forma de recuperarla.
+                 La dejamos siempre disponible como columna opcional (oculta por defecto). -->
+            <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='purchase_order_id']" position="attributes">
+                <attribute name="column_invisible"/>
+            </xpath>
+
             <div name='button_box' position="inside">
                 <field name="has_purchases" invisible="1"/>
             </div>


### PR DESCRIPTION
## Qué

En la lista de `invoice_line_ids` del formulario de `account.move`, la columna `purchase_order_id` que agrega `purchase` viene con:

```xml
column_invisible="parent.move_type not in ('in_invoice', 'in_refund')"
optional="hide"
```

Este PR vacía ese `column_invisible` desde `purchase_ux`, dejando la columna siempre disponible como columna opcional.

## Por qué

El renderer de list **excluye del menú de columnas opcionales** cualquier columna cuyo `column_invisible` evalúe truthy — no la destilda, la saca del menú:

```js
// web/static/src/views/list/list_renderer.js
get optionalFieldGroups() {
    const optionalColumns = this.allColumns.filter(
        (col) => col.optional && !this.evalColumnInvisible(col.column_invisible)
    );
```

Con lo cual, cuando la condición no se cumple, el usuario no tiene forma de activar la columna ni de distinguir ese estado de "esta columna no existe". El caso reportado fue sobre notas de crédito de proveedor (`in_refund`), donde la condición **sí** se cumple y la opción igual no figuraba en el menú: con este modificador, cualquier falla transitoria en la evaluación de `parent.move_type` se convierte en un bug irrecuperable desde la interfaz.

Ajustar la condición no alcanza: cualquier `column_invisible` sobre una columna `optional` produce el mismo efecto. Es el mismo patrón que `account_ux` ya aplica sobre `price_total` en esta misma lista.

## Costo

La opción aparece también en facturas de cliente, donde el campo viene vacío. Es una entrada más en el menú de columnas, no una columna visible: sigue con `optional="hide"`.

## Test plan

- Usuario en `purchase.group_purchase_user`, sobre una factura **y** una nota de crédito de proveedor → solapa de líneas → menú de columnas: "Orden de compra" aparece destildada; al tildarla, la columna muestra la OC de cada línea.
- Sobre una factura de cliente: la opción también aparece; al tildarla, la columna queda vacía.
- Usuario sin `purchase.group_purchase_user`: la opción no aparece — el campo se sigue filtrando server-side por `groups`.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125399
