### PR TITLE
[IMP] purchase_ux, purchase_order_type_ux: add field help

### DIFF
--- a/purchase_order_type_ux/__manifest__.py
+++ b/purchase_order_type_ux/__manifest__.py
@@ -20,7 +20,7 @@
 
 {
     "name": "Purchase Order Type UX",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.3.1",
     "category": "Purchases",
     "sequence": 14,
     "summary": "",

--- a/purchase_order_type_ux/i18n/es.po
+++ b/purchase_order_type_ux/i18n/es.po
@@ -28,9 +28,25 @@ msgid "Bill Control"
 msgstr "Control de facturación"
 
 #. module: purchase_order_type_ux
+#: model:ir.model.fields,help:purchase_order_type_ux.field_purchase_order_type__purchase_method
+msgid ""
+"Default invoicing method for orders of this type: bill based on ordered "
+"quantities or on received quantities."
+msgstr ""
+"Método de facturación por defecto de las órdenes de este tipo: facturar según "
+"las cantidades pedidas o según las recibidas."
+
+#. module: purchase_order_type_ux
 #: model:ir.model.fields,field_description:purchase_order_type_ux.field_purchase_order_type__journal_id
 msgid "Billing Journal"
 msgstr "Diario de facturación"
+
+#. module: purchase_order_type_ux
+#: model:ir.model.fields,help:purchase_order_type_ux.field_purchase_order_type__journal_id
+msgid "Accounting journal used to register the vendor bill of orders of this type."
+msgstr ""
+"Diario contable que se usará para registrar la factura de proveedor de las "
+"órdenes de este tipo."
 
 #. module: purchase_order_type_ux
 #: model:ir.model.fields,field_description:purchase_order_type_ux.field_purchase_order_type__picking_type_id
@@ -112,6 +128,11 @@ msgstr "Sobre cantidades recibidas"
 #: model:ir.model.fields,field_description:purchase_order_type_ux.field_purchase_order_type__payment_term_id
 msgid "Payment Term"
 msgstr "Términos del Pago"
+
+#. module: purchase_order_type_ux
+#: model:ir.model.fields,help:purchase_order_type_ux.field_purchase_order_type__payment_term_id
+msgid "Payment terms applied by default to purchase orders of this type."
+msgstr "Plazo de pago que se aplica por defecto a las órdenes de compra de este tipo."
 
 #. module: purchase_order_type_ux
 #: model_terms:ir.ui.view,arch_db:purchase_order_type_ux.view_purchase_order_type_search_inherit

--- a/purchase_order_type_ux/i18n/purchase_order_type_ux.pot
+++ b/purchase_order_type_ux/i18n/purchase_order_type_ux.pot
@@ -21,8 +21,20 @@ msgid "Bill Control"
 msgstr ""
 
 #. module: purchase_order_type_ux
+#: model:ir.model.fields,help:purchase_order_type_ux.field_purchase_order_type__purchase_method
+msgid ""
+"Default invoicing method for orders of this type: bill based on ordered "
+"quantities or on received quantities."
+msgstr ""
+
+#. module: purchase_order_type_ux
 #: model:ir.model.fields,field_description:purchase_order_type_ux.field_purchase_order_type__journal_id
 msgid "Billing Journal"
+msgstr ""
+
+#. module: purchase_order_type_ux
+#: model:ir.model.fields,help:purchase_order_type_ux.field_purchase_order_type__journal_id
+msgid "Accounting journal used to register the vendor bill of orders of this type."
 msgstr ""
 
 #. module: purchase_order_type_ux
@@ -104,6 +116,11 @@ msgstr ""
 #. module: purchase_order_type_ux
 #: model:ir.model.fields,field_description:purchase_order_type_ux.field_purchase_order_type__payment_term_id
 msgid "Payment Term"
+msgstr ""
+
+#. module: purchase_order_type_ux
+#: model:ir.model.fields,help:purchase_order_type_ux.field_purchase_order_type__payment_term_id
+msgid "Payment terms applied by default to purchase orders of this type."
 msgstr ""
 
 #. module: purchase_order_type_ux

--- a/purchase_order_type_ux/models/purchase_order_type.py
+++ b/purchase_order_type_ux/models/purchase_order_type.py
@@ -15,8 +15,15 @@ class PurchaseOrderType(models.Model):
             ("receive", "On received quantities"),
         ],
         string="Bill Control",
+        help="Default invoicing method for orders of this type: bill based on ordered "
+        "quantities or on received quantities.",
     )
-    payment_term_id = fields.Many2one(comodel_name="account.payment.term", string="Payment Term", check_company=True)
+    payment_term_id = fields.Many2one(
+        comodel_name="account.payment.term",
+        string="Payment Term",
+        check_company=True,
+        help="Payment terms applied by default to purchase orders of this type.",
+    )
     picking_type_id = fields.Many2one(
         "stock.picking.type",
         "Deliver To",
@@ -47,6 +54,7 @@ class PurchaseOrderType(models.Model):
         domain="journal_domain",
         check_company=False,
         string="Billing Journal",
+        help="Accounting journal used to register the vendor bill of orders of this type.",
     )
     set_locked_on_confirmation = fields.Boolean(
         string="Lock on Confirmation",

--- a/purchase_ux/__manifest__.py
+++ b/purchase_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase UX",
-    "version": "19.0.1.8.0",
+    "version": "19.0.1.8.1",
     "category": "Purchases",
     "sequence": 14,
     "summary": "Purchase order improvements: currency change, price updates, invoice controls and menu enhancements",

--- a/purchase_ux/__manifest__.py
+++ b/purchase_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Purchase UX",
-    "version": "19.0.1.10.0",
+    "version": "19.0.1.10.1",
     "category": "Purchases",
     "sequence": 14,
     "summary": "Purchase order improvements: currency change, price updates, invoice controls and menu enhancements",

--- a/purchase_ux/i18n/es.po
+++ b/purchase_ux/i18n/es.po
@@ -205,6 +205,17 @@ msgid "Force Invoiced Status"
 msgstr "Forzar estado facturado"
 
 #. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_purchase_order__force_invoiced_status
+msgid ""
+"Forces the invoicing status of the whole order, ignoring the per-line "
+"computation: 'Nothing to Bill' marks it as having nothing pending and 'No "
+"Bill to Receive' as already invoiced."
+msgstr ""
+"Fuerza el estado de facturación de toda la orden ignorando el cálculo por "
+"líneas: «Nada que facturar» la marca como sin pendientes y «Sin factura por "
+"recibir» como ya facturada."
+
+#. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_account_bank_statement_line__has_purchases
 #: model:ir.model.fields,field_description:purchase_ux.field_account_move__has_purchases
 msgid "Has Purchases?"
@@ -301,6 +312,8 @@ msgid ""
 "Lines shown per page on the order. Leave empty to keep the default; a lower "
 "value (e.g. 40) speeds up very long orders."
 msgstr ""
+"Líneas que se muestran por página en el pedido. Dejalo vacío para conservar el "
+"valor por defecto; un valor más bajo (por ej. 40) agiliza los pedidos muy largos."
 
 #. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_product_product__main_seller_id
@@ -448,7 +461,7 @@ msgstr "Selecciona una tasa de cambio para aplicar en la orden de compra"
 #. module: purchase_ux
 #: model:ir.model.fields,help:purchase_ux.field_purchase_change_currency__currency_id
 msgid "Select a currency to apply on the purchase order"
-msgstr "Seleeciona una moneda para aplicar en la orden de compra"
+msgstr "Selecciona una moneda para aplicar en la orden de compra"
 
 #. module: purchase_ux
 #. odoo-python
@@ -507,6 +520,16 @@ msgstr "Actualizar Precios de Proveedores"
 #: model:ir.model.fields,field_description:purchase_ux.field_purchase_order_line_add_to_invoice__voucher
 msgid "Voucher"
 msgstr "Remito"
+
+#. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_purchase_order_line_add_to_invoice__voucher
+msgid ""
+"Remito (delivery note) number: when set, only the quantities received under "
+"that remito are added to the invoice, instead of everything pending to "
+"invoice."
+msgstr ""
+"Número de remito: al indicarlo, solo se agregan a la factura las cantidades "
+"recibidas en ese remito, en lugar de todo lo pendiente de facturar."
 
 #. module: purchase_ux
 #: model:ir.model.fields.selection,name:purchase_ux.selection__purchase_order_line__invoice_status__to_invoice

--- a/purchase_ux/i18n/purchase_ux.pot
+++ b/purchase_ux/i18n/purchase_ux.pot
@@ -191,6 +191,14 @@ msgid "Force Invoiced Status"
 msgstr ""
 
 #. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_purchase_order__force_invoiced_status
+msgid ""
+"Forces the invoicing status of the whole order, ignoring the per-line "
+"computation: 'Nothing to Bill' marks it as having nothing pending and 'No "
+"Bill to Receive' as already invoiced."
+msgstr ""
+
+#. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_account_bank_statement_line__has_purchases
 #: model:ir.model.fields,field_description:purchase_ux.field_account_move__has_purchases
 msgid "Has Purchases?"
@@ -486,6 +494,14 @@ msgstr ""
 #. module: purchase_ux
 #: model:ir.model.fields,field_description:purchase_ux.field_purchase_order_line_add_to_invoice__voucher
 msgid "Voucher"
+msgstr ""
+
+#. module: purchase_ux
+#: model:ir.model.fields,help:purchase_ux.field_purchase_order_line_add_to_invoice__voucher
+msgid ""
+"Remito (delivery note) number: when set, only the quantities received under "
+"that remito are added to the invoice, instead of everything pending to "
+"invoice."
 msgstr ""
 
 #. module: purchase_ux

--- a/purchase_ux/models/purchase_order.py
+++ b/purchase_ux/models/purchase_order.py
@@ -19,6 +19,9 @@ class PurchaseOrder(models.Model):
         ],
         tracking=True,
         copy=False,
+        help="Forces the invoicing status of the whole order, ignoring the per-line computation: "
+        "'Nothing to Bill' marks it as having nothing pending and "
+        "'No Bill to Receive' as already invoiced.",
     )
 
     @api.depends("force_invoiced_status")

--- a/purchase_ux/wizards/purchase_order_line_add_to_invoice.py
+++ b/purchase_ux/wizards/purchase_order_line_add_to_invoice.py
@@ -39,7 +39,10 @@ class PurchaseOrderLineAddToInvoice(models.TransientModel):
         "('state', '=', 'draft'), "
         "('move_type', 'in', ['in_invoice', 'in_refund'])]",
     )
-    voucher = fields.Char()
+    voucher = fields.Char(
+        help="Remito (delivery note) number: when set, only the quantities received under "
+        "that remito are added to the invoice, instead of everything pending to invoice.",
+    )
 
     @api.model
     def get_purchase_lines(self):


### PR DESCRIPTION
## What
Add `help` (English in code, Spanish in `i18n/es.po`) to client-facing fields:

**purchase_ux**
- `force_invoiced_status` (`purchase.order`): overrides the order invoicing status ignoring the per-line computation.
- `voucher` (`purchase.order.line.add_to_invoice`): the remito number restricts which received quantities are added to the invoice.

**purchase_order_type_ux** (`purchase.order.type` config)
- `purchase_method`: default bill control (ordered vs received quantities) for orders of this type.
- `journal_id`: journal used to register the vendor bill of orders of this type.
- `payment_term_id`: payment terms applied by default to orders of this type.

Also fills/fixes a couple of existing `purchase_ux` help translations.

## Why
Fields whose effect is not conveyed by the label. Part of R&D task 71629, Services & Supply Chain team batch (same branch `19.0-t-71629-les` as the sibling PRs, single runbot build).

## Test plan
- Purchase order → force-invoiced-status tooltip; "Add to invoice" wizard → voucher tooltip.
- Configuration → Purchase Order Types → the three fields show their tooltips.
- Base in es_AR/es_419: tooltips render in Spanish.

Tarea: https://www.adhoc.inc/odoo/project.task/71629